### PR TITLE
Speedup DynamicSumTypes benchmark

### DIFF
--- a/benchmark/dsymtypes.jl
+++ b/benchmark/dsymtypes.jl
@@ -3,27 +3,27 @@ module DynamicSumTypesBench
 using Random
 using DynamicSumTypes
 
-@kwdef struct A
-    common_field::Int = 1
+Base.@kwdef struct A
+    common_field::Int = 0
     a::Bool = true
     b::Int = 10
 end
-@kwdef struct B
-    common_field::Int = 1
-    c::Int = 1
-    d::Float64 = 1.0
-    e::Complex = 1.0 + 1.0im
+Base.@kwdef struct B
+    common_field::Int = 0
+    a::Int = 1
+    b::Float64 = 1.0
+    d::Complex = 1 + 1.0im # not isbits
 end
-@kwdef struct C
-    common_field::Int = 1
-    f::Float64 = 2.0
-    g::Bool = false
-    h::Float64 = 3.0
-    i::Complex{Float64} = 1.0 + 2.0im
+Base.@kwdef struct C
+    common_field::Int = 0
+    b::Float64 = 2.0
+    d::Bool = false
+    e::Float64 = 3.0
+    k::Complex{Real} = 1 + 2im # not isbits
 end
-@kwdef struct D
-    common_field::Int = 1
-    l::Any = "hi"
+Base.@kwdef struct D
+    common_field::Int = 0
+    b::Any = "hi" # not isbits
 end
 
 @sumtype AT(A,B,C,D)
@@ -43,9 +43,9 @@ function main!(xs)
     end
 end
 
-main_each(x::A) = AT(B(x.common_field+1, x.a, x.b, x.b))
-main_each(x::B) = AT(C(x.common_field-1, x.d, isodd(x.c), x.d, x.e))
-main_each(x::C) = AT(D(x.common_field+1, isodd(x.common_field) ? "hi" : "bye"))
-main_each(x::D) = AT(A(x.common_field-1, x.l=="hi", x.common_field))
+main_each(x::A) = AT(B(x.common_field + 1, x.a, x.b, x.b))
+main_each(x::B) = AT(C(x.common_field - 1, x.b, isodd(x.a), x.b, x.d))
+main_each(x::C) = AT(D(x.common_field + 1, isodd(x.common_field) ? "hi" : "bye"))
+main_each(x::D) = AT(A(x.common_field - 1, x.b == "hi", x.common_field))
 
 end # module


### PR DESCRIPTION
This is on pair with the base version on my pc. It uses the same structs as the one in the `base.jl` file making the comparison more correct.