### PR TITLE
Fix subtyping of ADT

### DIFF
--- a/src/data/emit/type.jl
+++ b/src/data/emit/type.jl
@@ -9,7 +9,7 @@
         name=Symbol("typeof($(info.def.head.name))"),
         fields=[JLField(; name=:data, type=:(Union{$(union_params...)}))],
         typevars=info.whereparams,
-	supertype=info.def.head.supertype,
+	supertype=isnothing(info.def.head.supertype) ? nothing : guess_self_as_any(info.def, info.def.head.supertype), 
     )
 
     binding = if isempty(info.params)

--- a/src/data/emit/type.jl
+++ b/src/data/emit/type.jl
@@ -9,6 +9,7 @@
         name=Symbol("typeof($(info.def.head.name))"),
         fields=[JLField(; name=:data, type=:(Union{$(union_params...)}))],
         typevars=info.whereparams,
+	supertype=info.def.head.supertype,
     )
 
     binding = if isempty(info.params)

--- a/test/data/emit/basic.jl
+++ b/test/data/emit/basic.jl
@@ -19,7 +19,9 @@ using Moshi.Data:
     Anonymous,
     Singleton
 
-@data Message begin
+abstract type AbstractMessage end
+
+@data Message <: AbstractMessage begin
     Quit
     struct Move
         x::Int
@@ -36,6 +38,7 @@ end
     @test variants(Message.Type) ==
         (Message.Quit, Message.Move, Message.Write, Message.ChangeColor)
 
+    @test Message.Type <: AbstractMessage
     @testset "Quit" begin
         x = Message.Quit()
         @test variants(x) ==


### PR DESCRIPTION
As per #27, `@data` generated `Type` was not being successfully subtyped at creation if a supertype was provided in the definition.

Minimal non-working example:

```julia
julia> abstract type AbstractADT end

julia> struct MyStruct end

julia> @data MyADT <: AbstractADT begin
       Member1
       Member2(MyStruct)
       end
Main.MyADT2

julia> MyADT.Type <: AbstractADT
false
```

After the PR is merged, subtyping will work and it will be covered under a test.