### PR TITLE
adt baremodule error replaced with $Base.error

### DIFF
--- a/src/data/emit/convert.jl
+++ b/src/data/emit/convert.jl
@@ -10,7 +10,7 @@
     end
     head_str = string(info.def.head.name, ".", info.type_head)
     jl.otherwise = quote
-        error("unexpected type conversion from \
+        $Base.error("unexpected type conversion from \
         $($Data.variant_name(value)) to $($(head_str))")
     end
 

--- a/src/data/emit/getproperty.jl
+++ b/src/data/emit/getproperty.jl
@@ -3,14 +3,14 @@
     for storage in info.storages
         if isnothing(storage.parent.fields)
             jl[:(data isa $(storage.name))] = quote
-                error("singleton variant has no fields")
+                $Base.error("singleton variant has no fields")
             end
             continue
         end
 
         if storage.parent.kind == Anonymous
             jl[:(data isa $(storage.name))] = quote
-                error("anonymous variant has no named fields")
+                $Base.error("anonymous variant has no named fields")
             end
             continue
         end
@@ -22,7 +22,7 @@
             end
         end
         variant_fields.otherwise = quote
-            error("unknown field name: $name")
+            $Base.error("unknown field name: $name")
         end
 
         jl[:(data isa $(storage.name))] = codegen_ast(variant_fields)

--- a/src/data/emit/getproperty.jl
+++ b/src/data/emit/getproperty.jl
@@ -28,7 +28,7 @@
         jl[:(data isa $(storage.name))] = codegen_ast(variant_fields)
     end
     jl.otherwise = quote
-        error("unreachable reached")
+        $Base.error("unreachable reached")
     end
 
     return quote
@@ -64,7 +64,7 @@ end
         jl[:(data isa $(storage.name))] = codegen_ast(variant_fields)
     end
     jl.otherwise = quote
-        error("unreachable reached")
+        $Base.error("unreachable reached")
     end
 
     if isempty(info.params)

--- a/src/data/emit/reflect.jl
+++ b/src/data/emit/reflect.jl
@@ -50,7 +50,7 @@ end
     end
 
     jl.otherwise = quote
-        error("unreachable reached")
+        $Base.error("unreachable reached")
     end
 
     on_type = expr_map(info.storages) do storage
@@ -88,7 +88,7 @@ end
     end
 
     jl.otherwise = quote
-        error("unreachable reached")
+        $Base.error("unreachable reached")
     end
 
     return quote
@@ -169,7 +169,7 @@ end
         end
     end
     jl.otherwise = quote
-        error("unreachable reached")
+        $Base.error("unreachable reached")
     end
 
     return if isempty(info.params)
@@ -209,7 +209,7 @@ end
         end
     end
     jl.otherwise = quote
-        error("unreachable reached")
+        $Base.error("unreachable reached")
     end
 
     unknown_variant = quote


### PR DESCRIPTION
Resolves #30.

After this commit:
```julia
julia> @data X begin
           A
       end;

julia> X.A().x
ERROR: singleton variant has no fields
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] getproperty(value::Main.X.var"typeof(X)", name::Symbol)
   @ Main.X ~/git/moshi_error_fix/Moshi.jl/src/data/emit/getproperty.jl:6
 [3] top-level scope
   @ REPL[6]:1
```

I also did the same interpolation in a few other places where the adt module would call error instead of (Base).error.

My main motivation for this PR comes from the fact that before this commit when developing a package that depends on Moshi, using JET.test_package from [JET.jl](https://github.com/aviatesk/JET.jl) in the tests (of my package) these unreachable `error` calls show up as test failures if an adt module contains them. I also like using JET as kind of julia version of rust's clippy/bacon so this became annoying fast. Interestingly, JET doesn't complain about the  `error("unreachable reached")` lines in the generated module, so I left them as they are for now. Maybe if these became reachable through some mistake JET would report them? There is one line in data/emit/getproperty.jl file where an error("unreachable reached") already has the $Base.error interpolation, I didn't modify this.

@Roger-luo Am I understanding this correctly?  Should all calls to `error` in the adt module be `(Base).error` (including the unreachable ones)? Do you have thoughts on if/how this sort of thing should be tested?