### PR TITLE
Qualify ADT in match example

### DIFF
--- a/docs/src/content/docs/data/syntax.mdx
+++ b/docs/src/content/docs/data/syntax.mdx
@@ -147,10 +147,10 @@ This is always the inverse operation of the generated constructor. Taking the `M
 
 ```julia
 @match message begin
-    Quit() => "Quit"
-    Move(x, y) => "Move to $(x), $(y)"
-    Write(msg) => "Write: $msg"
-    ChangeColor(r, g, b) => "Change color to ($r, $g, $b)"
+    Message.Quit() => "Quit"
+    Message.Move(x, y) => "Move to $(x), $(y)"
+    Message.Write(msg) => "Write: $msg"
+    Message.ChangeColor(r, g, b) => "Change color to ($r, $g, $b)"
     _ => "Unknown"
 end
 ```
@@ -163,6 +163,6 @@ pattern is also supported:
 
 ```julia
 @match message begin
-    Move(;y=10, x) => x
+    Message.Move(;y=10, x) => x
 end
 ```


### PR DESCRIPTION
To avoid an UndefVarError: `Quit` not defined in the match.

```julia
using Moshi.Data: @data
using Moshi.Match: @match

@data Message begin
    Quit
    struct Move
        x::Int
        y::Int
    end

    Write(String)
    ChangeColor(Int, Int, Int)
end

message = Message.Move(1,2)

@match message begin
    Message.Quit() => "Quit"
    Message.Move(x, y) => "Move to $(x), $(y)"
    Message.Write(msg) => "Write: $msg"
    Message.ChangeColor(r, g, b) => "Change color to ($r, $g, $b)"
    _ => "Unknown"
end
```