### PR TITLE
Docs: Fix broken internal links

### DIFF
--- a/docs/src/content/docs/data/syntax.mdx
+++ b/docs/src/content/docs/data/syntax.mdx
@@ -13,7 +13,7 @@ The algebraic data type can be defined using `@data` macro. It can be imported f
 using Moshi.Data: @data
 ```
 
-The `Moshi.Data` module also defines a set of reflection functions to work with the algebraic data types. You can check [Reflection](reflection) for more information. All the name can be imported together using:
+The `Moshi.Data` module also defines a set of reflection functions to work with the algebraic data types. You can check [Reflection](/Moshi.jl/data/reflection) for more information. All the name can be imported together using:
 
 ```julia
 using Moshi.Data.Prelude

--- a/docs/src/content/docs/data/understand.mdx
+++ b/docs/src/content/docs/data/understand.mdx
@@ -209,7 +209,7 @@ this allows Julia to perform constant propagation & folding when the variant typ
 
 ## Reflections
 
-The rest is generating reflections accordingly. Please see the [Reflections](reflection) section.
+The rest is generating reflections accordingly. Please see the [Reflections](/Moshi.jl/data/reflection) section.
 
 ## Supporting Type Parameters
 

--- a/docs/src/content/docs/match/syntax.mdx
+++ b/docs/src/content/docs/match/syntax.mdx
@@ -136,7 +136,7 @@ end
 
 <Aside type="note">
 The call pattern is one of the extensible pattern in `Moshi`. You can define how to deconstruct
-a type by overloading the `decons_call` method. See [Extending Patterns](extend) for more details.
+a type by overloading the `decons_call` method. See [Extending Patterns](/Moshi.jl/match/extend) for more details.
 </Aside>
 
 

--- a/docs/src/content/docs/start/algebra-data-type.mdx
+++ b/docs/src/content/docs/start/algebra-data-type.mdx
@@ -133,14 +133,14 @@ end
 And now you can see that pattern matching is exactly why we love Julia! Julia's multiple dispatch
 is a kind of pattern matching on types. Moshi brings you one step further -- pattern matching values,
 types and many more! Combined with pattern matching, Moshi gives you the best experience working with ADTs.
-See next introduction section [Pattern Matching - What is it?](match) to learn more about Moshi's pattern
+See next introduction section [Pattern Matching - What is it?](/Moshi.jl/start/match) to learn more about Moshi's pattern
 matching.
 
 <Aside type="tip">
 
 Syntax-wise, Moshi's `@data` is almost the same as rust `enum`. However, the declared name `Expr` is actually
 only a module. To specify the static type of `Expr`, one needs to write `Expr.Type` instead.
-See [Syntax & Examples](../data/syntax) and [Understanding `@data`](../data/understand) for more examples and
+See [Syntax & Examples](/Moshi.jl/data/syntax) and [Understanding `@data`](/Moshi.jl/data/understand) for more examples and
 explainations.
 
 </Aside>

--- a/docs/src/content/docs/start/getting-started.md
+++ b/docs/src/content/docs/start/getting-started.md
@@ -59,11 +59,11 @@ end
 
 ## Further Reading
 
-- Examples and detailed syntax for `@data`: [ADT Syntax](../../data/syntax)
-- Builtin patterns for `@match`: [Builtin Patterns](../../match/syntax/#builtin-patterns)
-- The `@derive` macro: [Syntax and Examples](../../start/derive/)
+- Examples and detailed syntax for `@data`: [ADT Syntax](/Moshi.jl/data/syntax)
+- Builtin patterns for `@match`: [Builtin Patterns](/Moshi.jl/match/syntax/#builtin-patterns)
+- The `@derive` macro: [Syntax and Examples](/Moshi.jl/start/derive/)
 
 To understand how Moshi works, you can check the following sections:
 
-- [Understanding What Happens | Algebraic Data Type](../../data/understand)
-- [Behind the Scene | Pattern Matching](../../match/behind)
+- [Understanding What Happens | Algebraic Data Type](/Moshi.jl/data/understand)
+- [Behind the Scene | Pattern Matching](/Moshi.jl/match/behind)

--- a/docs/src/content/docs/start/match.mdx
+++ b/docs/src/content/docs/start/match.mdx
@@ -59,7 +59,7 @@ end
 ```
 
 Moshi offers a lot of builtin patterns. To learn more about builtin patterns
-please read [Builtin Patterns](Moshi.jl/match/syntax/#builtin-patterns).
+please read [Builtin Patterns](/Moshi.jl/match/syntax/#builtin-patterns).
 
 ## Extensible Pattern Matching
 
@@ -72,7 +72,7 @@ Moshi takes extensibility seriously and goes one step further - we allow you cus
 pattern not only based on underlying type (by overloading `decons_call`). We also allow
 you registering your own syntax and decide what it gets lowered to.
 
-See [extending pattern match](Moshi.jl/match/extend) to understand how to extend pattern matching
+See [extending pattern match](/Moshi.jl/match/extend) to understand how to extend pattern matching
 for your own data structure.
 
 ## Zero Dependency Guarantee


### PR DESCRIPTION
Fixes #35.

I used a tool to find 9 other broken internal links in the docs. I wanted to fix the relative paths first, but noticed when running `npm run dev` in `/docs/` relative paths that are fine online are broken locally and vice versa. So instead this changes all internal links to absolute links to avoid this confusion.

#35 was just missing an initial `/`.