### PR TITLE
vector type matching

### DIFF
--- a/src/match/emit/collection/vect.jl
+++ b/src/match/emit/collection/vect.jl
@@ -8,9 +8,23 @@ function decons(::Type{Pattern.Ref}, ctx::PatternContext, pat::Pattern.Type)
     #    will try to find the index that returns the input
     #    value.
     # 2 is not supported for now because I don't see any use case.
-    return CollectionDecons(ctx, pat, pat.args) do _
-        :($Base.Vector{$(pat.head)})
+    coll = CollectionDecons(ctx, pat, pat.args) do _
+        :($Base.Vector{<:$(pat.head)})
     end
+    set_view_type_check!(coll) do view, eltype
+        # For the pattern
+        #   AP[_, v::VP..., _]
+        # matching on some vector of the form
+        #   A[_, V[...]..., _]
+        # the vector is illegal unless V <: A
+        # and the match fails elsewhere unless A <: AP
+        # so V <: A <: AP
+        # want to return V <: VP
+        (pat.head == eltype # if AP == VP we know at macro time
+         || :(eltype($view) <: $eltype # if A <: VP can avoid iteration
+              || all(Base.Fix2(isa, $eltype), $view)))
+    end
+    return coll
 end
 
 function decons(::Type{Pattern.Vector}, ctx::PatternContext, pat::Pattern.Type)
@@ -18,7 +32,8 @@ function decons(::Type{Pattern.Vector}, ctx::PatternContext, pat::Pattern.Type)
         :($Base.Vector)
     end
     set_view_type_check!(coll) do view, eltype
-        :(eltype($view) == $eltype)
+        :(eltype($view) <: $eltype
+          || all(Base.Fix2(isa, $eltype), $view))
     end
     return coll
 end

--- a/src/match/emit/collection/vect.jl
+++ b/src/match/emit/collection/vect.jl
@@ -9,7 +9,7 @@ function decons(::Type{Pattern.Ref}, ctx::PatternContext, pat::Pattern.Type)
     #    value.
     # 2 is not supported for now because I don't see any use case.
     coll = CollectionDecons(ctx, pat, pat.args) do _
-        :($Base.Vector{<:$(pat.head)})
+        :($Base.Vector{$(pat.head)})
     end
     set_view_type_check!(coll) do view, eltype
         # For the pattern


### PR DESCRIPTION
attempt at fixing #48

Matching type annotated splats within vectors currently has some surprising interactions with supertypes, Union, or Any.

 From #48:
```julia
function foo(something)
    @match something begin
        Any[ a::Int, b::String... ] => "first"
        Any[ a::Int, b::Vector{Int}... ] => "second"
    end
end
# before PR
foo([ 1, [2, 3] ]) # -> "first"
# after PR
foo([ 1, [2, 3] ]) # -> "second"
```

A variation without the Any in the patterns:
```julia
function bar(something)
    @match something begin
        [ a::Int, b::String... ] => "first"
        [ a::Int, b::Vector{Int}... ] => "second"
        _ => "third"
    end
end
# before PR
bar([ 1, [2, 3] ]) # -> "third"
# after PR
bar([ 1, [2, 3] ]) # -> "second"
```

The type checking is different if the pattern is a `Vector` as in `bar` or a `Ref` as in `foo`. Note that by `Ref` I'm referring purely to the syntax of a symbol immediately followed by square brackets.

Before this PR there was no view type check for `Ref`s so the type annotation on the splat is totally ignored. This is why the first pattern in the `foo` example is matched. In fact that annotation is compiled away:

```julia
@match [ 1, [2, 3]] begin
    Any[a::Int, b::DoesntEvenNeedToBeDefined...] => "sure"
end # -> "sure"
# after PR: UndefVarError
```

For a `Vector` before this PR the implementation checks if the eltype of the view matches the type provided in the splat pattern. However, the eltype of the view is always the same as the eltype of vector! So since `Any != Vector{Int}` we don't match the pattern in `bar`.

This type check was also very specific, it wouldn't match supertypes like other Moshi patterns:
```julia
@match Union{Int, Vector{Int}}[ 1, [2, 3]] begin
    [a::Int, b::Vector{Int}...] => "first"
    [a::Int, b::Any...] => "second"
    [a::Number, b::Union{<:Number, Vector{<:Number}}...] => "third"
    [a::Int, b::Union{Int, Vector{Int}}...] => "fourth"
end # before PR -> "fourth"
# after PR -> "first" (they all match in the after PR)
```

```julia
@match Union{Int, Vector{Int}}[ 1, [2, 3]] begin
    Any[a::Int, b::Vector{<:Any}...] => "first"
    Union{Int, Vector{<:Any}}[a::Int, b::Vector{<:Any}...] => "second"
    Union{Int, Vector{<:Number}}[a::Number, b::Union{<:Number, Vector{<:Number}}...] => "third"
    Union{Int, Vector{Int}}[a::Int, b::Union{Int, Vector{Int}}...] => "fourth"
end # before PR -> "fourth"
```
~~`# after PR -> "first" (they all match in the after PR)`~~
edit: The behavior matching the type T in <T>[...] was actually reverted in the second commit of this PR as discussed below. One can do the following both before and after this PR:
```julia
@match Union{Int, Vector{Int}}[ 1, [2, 3]] begin
    Any[a::Int, b::Vector{<:Any}...] => "first"
    (<:Any)[a::Int, b::Vector{<:Any}...] => "second"
    (<:Union{<:Real, Vector{<:Number}})[a::Int, b::Vector{<:Any}...] => "third"
end # -> "second" (only the first pattern doesn't match)
```


In the most general case I don't see a way to verify that all elements of the view are of a particular type without actually checking each element. I'm not sure if that's the right thing to do in Moshi. Even when you do this iteration the view will have the same eltype as the parent vector. Maybe it would make sense to return a copy then, but that would probably complicate the implementation for a pretty niche scenario. Vectors without concrete types are pretty bad for performance all around, so I would think this pattern wouldn't be used much.

If this version is fine we could add the above examples as tests.