### PR TITLE
feat(data): allow function-call type annotations in @data fields

### DIFF
--- a/src/data/emit/cons.jl
+++ b/src/data/emit/cons.jl
@@ -111,6 +111,8 @@ function is_inferrable(param::Symbol, type)
         return param == type
     elseif Meta.isexpr(type, :curly)
         return any(is_inferrable(param, each) for each in type.args[2:end])
+    elseif Meta.isexpr(type, :call)
+        return any(is_inferrable(param, each) for each in type.args[2:end])
     else
         return false
     end

--- a/src/data/scan.jl
+++ b/src/data/scan.jl
@@ -49,6 +49,12 @@ function guess_self_as_any(def::TypeDef, expr)
         end
         Any in typevars && return Any # no need to specialize further
         return :($type{$(typevars...)})
+    elseif Meta.isexpr(expr, :call)
+        fn = guess_self_as_any(def, expr.args[1])
+        args = map(expr.args[2:end]) do arg
+            guess_self_as_any(def, arg)
+        end
+        return :($fn($(args...)))
     else
         return expr
     end
@@ -76,6 +82,12 @@ function guess_self_as_annotation(def::TypeDef, expr)
             guess_self_as_annotation(def, param)
         end
         return :($type{$(typevars...)})
+    elseif Meta.isexpr(expr, :call)
+        fn = guess_self_as_annotation(def, expr.args[1])
+        args = map(expr.args[2:end]) do arg
+            guess_self_as_annotation(def, arg)
+        end
+        return :($fn($(args...)))
     else
         return expr
     end

--- a/test/data/emit/call_type.jl
+++ b/test/data/emit/call_type.jl
@@ -1,0 +1,57 @@
+using Test
+using Moshi.Data: @data
+
+sym_union(T) = Union{T,Symbol}
+
+@data CallType begin
+    struct AxisAngle
+        n::sym_union(Vector{Float64}) = [1.0, 0.0, 0.0]
+        angle::sym_union(Float64) = 0.0
+    end
+    struct Quaternion
+        Q::sym_union(Vector{Float64}) = [1.0, 0.0, 0.0, 0.0]
+    end
+end
+
+@testset "CallType: function-call field types" begin
+    a = CallType.AxisAngle()
+    @test a.n == [1.0, 0.0, 0.0]
+    @test a.angle == 0.0
+
+    a2 = CallType.AxisAngle(n=:unset, angle=:unset)
+    @test a2.n === :unset
+    @test a2.angle === :unset
+
+    q = CallType.Quaternion()
+    @test q.Q == [1.0, 0.0, 0.0, 0.0]
+end
+
+wrap(T) = Vector{T}
+
+@data CallTypeParam{T} begin
+    struct Wrapped
+        v::wrap(T)
+    end
+end
+
+@testset "CallTypeParam{T}: TypeVar inferred through call" begin
+    w = CallTypeParam.Wrapped([1.0, 2.0])
+    @test w.v == [1.0, 2.0]
+end
+
+nested_union(T) = Union{T,Nothing}
+
+@data NestedCall begin
+    struct Inner
+        x::sym_union(nested_union(Int)) = 0
+    end
+end
+
+@testset "NestedCall: nested function calls in type position" begin
+    i = NestedCall.Inner()
+    @test i.x == 0
+    i2 = NestedCall.Inner(x=nothing)
+    @test i2.x === nothing
+    i3 = NestedCall.Inner(x=:tag)
+    @test i3.x === :tag
+end

--- a/test/data/emit/mod.jl
+++ b/test/data/emit/mod.jl
@@ -10,6 +10,7 @@ end
     include("option.jl")
     include("uninferable.jl")
     include("named.jl")
+    include("call_type.jl")
 end
 
 module TestCons


### PR DESCRIPTION
## Summary

- The `@data` macro previously didn't resolve `Expr(:call, ...)` field type annotations, so types like `n::f(Vector{Float64})` left bare `:f` symbols in the AST that the macro-emitted inner module couldn't look up — forcing users into `Core.eval(...)` workarounds.
- Add a `:call` branch to `guess_self_as_any` and `guess_self_as_annotation` in `src/data/scan.jl`, mirroring the existing `:curly` recursion: resolve the function and each argument against `def.mod` and splice them as concrete objects.
- Extend `is_inferrable` in `src/data/emit/cons.jl` to recurse through `:call` args so a TypeVar inside a function-call type (e.g. `f(T)` in `@data Foo{T}`) still triggers the auto-typed inferred constructor — matching today's behavior for `Vector{T}`.

## Motivation

Without this, expressing a field whose type is computed by a helper function required a workaround like:

```julia
Moshi.Data.@data RotationType begin
  struct AxisAngle
    n::(Core.eval(RotationType, quote
      import Base as __TMP
      __TMP.parentmodule(RotationType).DyadInterface._dyad_sym_union(__TMP.Vector{__TMP.Float64})
    end)) = [1.0, 0.0, 0.0]
    # …
  end
end
```

After this change, the same type can be written naturally:

```julia
sym_union(T) = Union{T, Symbol}

Moshi.Data.@data RotationType begin
  struct AxisAngle
    n::sym_union(Vector{Float64}) = [1.0, 0.0, 0.0]
    angle::sym_union(Float64) = 0.0
  end
end
```

## Scope

Limited to `Expr(:call, ...)`. `Expr(:where, ...)` has a similar fall-through but Base-exported names make common cases work today; leaving it for a follow-up keeps this PR focused.

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — all existing suites green (`data` 215 / `match` 85 / `derive` 6).
- [x] New tests in `test/data/emit/call_type.jl` cover:
  - defaults + Union branches for function-call types
  - `wrap(T)` in a parametric `@data Foo{T}` (verifies `is_inferrable` change)
  - nested calls: `sym_union(nested_union(Int))`
- [x] Reproduced the original `RotationType` example without the `Core.eval` shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)