### PR TITLE
derive(Eq): drop UnionAll unwrap before dispatching on variant_type

### DIFF
--- a/src/derive/eq.jl
+++ b/src/derive/eq.jl
@@ -39,9 +39,6 @@ function derive_impl(::Val{:Eq}, mod::Module, type::Module)
 end
 
 function eq_derive_variant_field(func, variant_type)
-    if variant_type isa UnionAll
-        variant_type = variant_type.body
-    end
     cache_indices = findall(Data.variant_fieldtypes(variant_type)) do type
         type <: Hash.Cache
     end


### PR DESCRIPTION
`eq_derive_variant_field` stripped `variant_type` to its `.body` if it was a `UnionAll`, so the subsequent `Data.variant_fieldtypes(variant_type)` call dispatched on the inner `DataType` containing a free `TypeVar`. That worked only because `Type{Foo.body} <: Type{Foo}` happened to hold under the old free- TypeVar subtype rules; under JuliaLang/julia#61876 that subtype is false, the parametric `variant_fieldtypes(::Type{Foo{T}}) where T` method matches instead, and the field-type loop then trips on `T <: Hash.Cache` with a `TypeError`.

Removing the unwrap leaves the original `UnionAll` for dispatch, which matches the `variant_fieldtypes(::Type{Foo})` method directly. The sibling `derive/hash.jl` already takes this approach.

The behavior of free TypeVars in subtyping was previously undefined (in effect a bug); JuliaLang/julia#61876 makes them well-defined singleton identities, which is what surfaces this latent issue.

This change was AI-generated and should be reviewed carefully before merging.