### PR TITLE
fix(match): respect splat type annotations in vector patterns

### DIFF
--- a/src/match/emit/collection/vect.jl
+++ b/src/match/emit/collection/vect.jl
@@ -8,9 +8,23 @@ function decons(::Type{Pattern.Ref}, ctx::PatternContext, pat::Pattern.Type)
     #    will try to find the index that returns the input
     #    value.
     # 2 is not supported for now because I don't see any use case.
-    return CollectionDecons(ctx, pat, pat.args) do _
+    coll = CollectionDecons(ctx, pat, pat.args) do _
         :($Base.Vector{$(pat.head)})
     end
+    set_view_type_check!(coll) do view, eltype
+        # For the pattern `AP[_, v::VP..., _]` matching a vector `A[_, V[...]..., _]`,
+        # the `value isa Vector{AP}` check emitted by `finish_decons` already pins the
+        # parent element type to `AP` (Julia's `Vector` is invariant), so the view's
+        # `eltype` is statically `AP`. We only need to verify the spliced elements are
+        # each a `VP`.
+        if pat.head == eltype
+            true # view eltype is statically `VP`, nothing left to check
+        else
+            :($Base.eltype($view) <: $eltype # fast path: avoid iterating the view
+            || $Base.all($Base.Fix2(isa, $eltype), $view))
+        end
+    end
+    return coll
 end
 
 function decons(::Type{Pattern.Vector}, ctx::PatternContext, pat::Pattern.Type)
@@ -18,7 +32,10 @@ function decons(::Type{Pattern.Vector}, ctx::PatternContext, pat::Pattern.Type)
         :($Base.Vector)
     end
     set_view_type_check!(coll) do view, eltype
-        :(eltype($view) == $eltype)
+        # The view shares the parent's (possibly abstract) `eltype`, so a bare
+        # `eltype(view) == VP` never matches a more specific element type. Fall back to
+        # checking each element when the static `eltype` is not already a subtype.
+        :($Base.eltype($view) <: $eltype || $Base.all($Base.Fix2(isa, $eltype), $view))
     end
     return coll
 end

--- a/test/match/examples/basic.jl
+++ b/test/match/examples/basic.jl
@@ -98,6 +98,37 @@ end
     [1, xs::Float64...] => xs
 end
 
+# https://github.com/Roger-luo/Moshi.jl/issues/48
+# the type annotation on a splat must be respected, both for the `T[...]` (Ref)
+# and the `[...]` (Vector) syntax, and must match element subtypes/supertypes
+# rather than requiring an exact `eltype` match.
+@test "second" == @match [1, [2, 3]] begin
+    Any[a::Int, b::String...] => "first"
+    Any[a::Int, b::Vector{Int}...] => "second"
+end
+
+@test "second" == @match [1, [2, 3]] begin
+    [a::Int, b::String...] => "first"
+    [a::Int, b::Vector{Int}...] => "second"
+    _ => "third"
+end
+
+# a splat annotation on a `Ref` pattern must not be silently compiled away
+@test_throws UndefVarError @match [1, [2, 3]] begin
+    Any[a::Int, b::ThisTypeIsNotDefined...] => "sure"
+end
+
+# splats match supertypes of the elements, like other Moshi patterns
+@test "matched" == @match Union{Int,Vector{Int}}[1, [2, 3]] begin
+    [a::Int, b::String...] => "nope"
+    [a::Int, b::Any...] => "matched"
+end
+
+# a splat matching zero elements trivially satisfies its annotation
+@test [] == @match [1] begin
+    [a::Int, b::String...] => b
+end
+
 struct Foo
     x::Int
     y::Int


### PR DESCRIPTION
## Summary

Fixes #48 and continues the fix started in #52.

Splat type annotations in `@match` vector patterns were effectively ignored, causing surprising matches. This confirmed the bug is still present on `main`:

```julia
foo(x) = @match x begin
    Any[a::Int, b::String...]      => "first"
    Any[a::Int, b::Vector{Int}...] => "second"
end
foo([1, [2, 3]])   # main: "first"   → fixed: "second"
```

### Root cause

- **`T[...]` (Ref) patterns** set *no* view type check at all, so a splat annotation like `b::String...` was silently compiled away. An undefined type in the annotation would even go unnoticed:
  ```julia
  @match [1, [2, 3]] begin
      Any[a::Int, b::ThisTypeIsNotDefined...] => "sure"  # main: "sure" (!), fixed: UndefVarError
  end
  ```
- **`[...]` (Vector) patterns** compared `eltype(view) == VP`. Since a `@view` always shares the parent's `eltype`, this never matched a *more specific* element type — e.g. `b::Vector{Int}...` failed against a `Vector{Any}` that holds a `Vector{Int}`.

### The fix

Both `Ref` and `Vector` splats now check `eltype(view) <: VP` (fast path, no iteration) and fall back to `all(Base.Fix2(isa, VP), view)`, so splats match element subtypes/supertypes consistently with the rest of Moshi's patterns.

- The `Ref` case keeps the invariant `value isa Vector{AP}` guard emitted by `finish_decons` (so `Int[...]` still requires a `Vector{Int}`, matching existing behavior — `test/match/examples/basic.jl:33`), and short-circuits to `true` at macro time when the declared element type equals the annotation.
- An empty splat view trivially satisfies its annotation (`all` over an empty view is `true`).

This mirrors the approach in #52, adapted to the current `Ref`/`Vector` split in `vect.jl` and with `Base`-qualified references for hygiene.

## Test plan

- Added regression tests in `test/match/examples/basic.jl` covering the issue #48 cases (both `Ref` and `Vector` syntax), supertype matching, the annotation-not-compiled-away behavior, and the empty-splat-view case.
- Full suite green: `data 259 | match 90 | derive 6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)