### PR TITLE
Bump patch version to v0.3.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Moshi"
 uuid = "2e0e35c7-a2e4-4343-998d-7ef72827ed2d"
 authors = ["Roger-luo<rogerluo.rl18@gmail.com>"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 ExproniconLite = "55351af7-c7e9-48d6-89ff-24e801d99491"


### PR DESCRIPTION
Patch release bundling the fixes/changes merged since v0.3.8:

- fix(match): respect splat type annotations in vector patterns (#67, fixes #48)
- allow using multiple empty structs (#66)
- feat: docstring support for `@data` variants (#64)
- ci: modernize GitHub Actions to current Julia standard

After merge I'll trigger `@JuliaRegistrator register` to publish v0.3.9 to the General registry; TagBot will then tag the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)