### PR TITLE
test(docs): verify Vercel PR preview

### DIFF
--- a/docs/scripts/vercel-ignore-build.sh
+++ b/docs/scripts/vercel-ignore-build.sh
@@ -4,6 +4,7 @@
 
 set -euo pipefail
 
+cd "$(git rev-parse --show-toplevel)"
 PATHS=(docs/)
 
 if [ -n "${VERCEL_GIT_PREVIOUS_SHA:-}" ] && [ -n "${VERCEL_GIT_COMMIT_SHA:-}" ]; then

--- a/docs/scripts/vercel-ignore-build.sh
+++ b/docs/scripts/vercel-ignore-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Vercel "Ignored Build Step": exit 0 = skip, exit 1 = build.
-# Runs from the repository root (not docs/).
+# Runs from the Vercel root directory (docs/). Git paths stay repo-relative.
 
 set -euo pipefail
 

--- a/docs/src/content/docs/dev/doc.md
+++ b/docs/src/content/docs/dev/doc.md
@@ -38,6 +38,8 @@ julia --project=docs/script docs/script/gendoc.jl
 
 ## Deploying to Vercel
 
+Vercel preview deployments run automatically on pull requests when files under `docs/` change.
+
 1. Import the repository on [Vercel](https://vercel.com).
 2. Set the **Root Directory** to `docs`.
 3. Vercel auto-detects Astro. The `vercel.json` in `docs/` configures the build.

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -3,5 +3,5 @@
   "outputDirectory": "dist",
   "framework": "astro",
   "installCommand": "npm install",
-  "ignoreCommand": "bash docs/scripts/vercel-ignore-build.sh"
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh"
 }


### PR DESCRIPTION
## Summary

Trivial change under `docs/` to test Vercel preview deployments.

- Adds one sentence to the developer docs about PR previews
- Should trigger a Vercel preview build (not production)

## Test plan

- [ ] Vercel bot comments with a preview URL on this PR
- [ ] Preview site loads at `*.vercel.app`
- [ ] Merging is optional — close without merging after verifying


Made with [Cursor](https://cursor.com)