### PR TITLE
feat(match): support splat interpolation in quoted Expr patterns

### DIFF
--- a/src/match/emit/expr.jl
+++ b/src/match/emit/expr.jl
@@ -1,12 +1,19 @@
 function decons(::Type{Pattern.Expression}, ctx::PatternContext, pat::Pattern.Type)
     return function expression(value)
+        # The `args` of an `Expr` is a plain `Vector{Any}`, so we reuse the
+        # collection machinery to deconstruct it. This gives us splat support
+        # (e.g. `:($f($arg0, $(args...)))`) and an exact length check for free,
+        # matching the semantics of the `[...]` and `(...)` patterns.
+        coll = CollectionDecons(ctx, pat, pat.args) do _
+            :($Base.Vector)
+        end
+        set_view_type_check!(coll) do view, eltype
+            :($Base.eltype($view) <: $eltype || $Base.all($Base.Fix2(isa, $eltype), $view))
+        end
         return and_expr(
             :($value isa Expr),
             :($value.head == $(QuoteNode(pat.head))),
-            map(enumerate(pat.args)) do (idx, each)
-                entry = :($value.args[$idx])
-                decons(ctx, each)(entry)
-            end...,
+            coll(:($value.args)),
         )
     end
 end

--- a/test/match/examples/expr.jl
+++ b/test/match/examples/expr.jl
@@ -113,4 +113,16 @@ end # match LineNumberNode
         :($f($a)) => (:matched, f, a)
         _ => :fallthrough
     end
+
+    # a type annotation on the splat is respected: it matches only when every
+    # captured element is of the annotated type
+    @test (:f, [:a, :b, :c]) == @match :(f(a, b, c)) begin
+        :($f($(rest::Symbol...))) => (f, rest)
+        _ => :nomatch
+    end
+
+    @test :nomatch == @match :(f(1, 2)) begin
+        :($f($(rest::Symbol...))) => (f, rest)
+        _ => :nomatch
+    end
 end # splatting pattern in Exprs

--- a/test/match/examples/expr.jl
+++ b/test/match/examples/expr.jl
@@ -73,3 +73,44 @@ end
         end => line
     end
 end # match LineNumberNode
+
+@testset "splatting pattern in Exprs (#53)" begin
+    # https://github.com/Roger-luo/Moshi.jl/issues/53
+    # a splat interpolation `$(args...)` inside a quoted `Expr` pattern should
+    # capture the remaining arguments, mirroring MLStyle's behavior.
+    expr = :(a = sin(5))
+    @test (:a, :sin, 5, Any[]) == @match expr begin
+        :($out = $f($arg0, $(args...))) => (out, f, arg0, args)
+        _ => nothing
+    end
+
+    # the trailing splat captures every remaining argument
+    @test (:f, 1, [2, 3, 4]) == @match :(f(1, 2, 3, 4)) begin
+        :($f($a, $(rest...))) => (f, a, rest)
+        _ => nothing
+    end
+
+    # a splat that consumes zero arguments still matches
+    @test (:g, 1, []) == @match :(g(1)) begin
+        :($f($a, $(rest...))) => (f, a, rest)
+        _ => nothing
+    end
+
+    # the captured splat elements keep their original (possibly nested) exprs
+    @test (:k, :a, [:(b + c), :d]) == @match :(k(a, b + c, d)) begin
+        :($f($x, $(mid...))) => (f, x, mid)
+        _ => nothing
+    end
+
+    # a leading splat before a fixed trailing argument
+    @test ([1, 2], 3) == @match :(h(1, 2, 3)) begin
+        :(h($(front...), $last)) => (front, last)
+        _ => nothing
+    end
+
+    # without a splat the argument count must match exactly
+    @test :fallthrough == @match :(f(1, 2)) begin
+        :($f($a)) => (:matched, f, a)
+        _ => :fallthrough
+    end
+end # splatting pattern in Exprs


### PR DESCRIPTION
## Summary

Fixes #53. Splat interpolation inside a quoted `Expr` pattern now works, so patterns like the MLStyle-style example from the issue match as expected:

```julia
expr = :(a = sin(5))

@match expr begin
    :($out = $f($arg0, $(args...))) => (out, f, arg0, args)
    _ => nothing
end
# (:a, :sin, 5, Any[])
```

Previously this errored with `invalid pattern: args...`.

## Root cause

The scanner already parsed `$(args...)` into a `Pattern.Splat` child nested inside `Pattern.Expression`. The problem was purely in the emit stage: `decons(::Type{Pattern.Expression}, ...)` in `src/match/emit/expr.jl` did naive index-based matching (`value.args[idx]` per child). It had no case for `Pattern.Splat` — so it fell through to the generic `decons(::Type, ...)` that throws `invalid pattern: $pat` — and it never checked the argument count.

## Fix

Reuse the existing `CollectionDecons` machinery — the same code path already used by the `[...]` (`Pattern.Vector`) and `(...)` (`Pattern.Tuple`) patterns — to deconstruct `Expr.args`. Since `Expr.args` is a plain `Vector{Any}`, this drops in cleanly and gives us, for free:

- **splat support** anywhere in the argument list (leading, middle, or trailing), and
- an **exact-length check** for the non-splat case, matching MLStyle's structural semantics (previously `:($f($a))` would incorrectly match `:(f(1, 2))` by ignoring trailing args).

## Tests

Added a `@testset "splatting pattern in Exprs (#53)"` in `test/match/examples/expr.jl` covering:

- the exact example from the issue (`(:a, :sin, 5, Any[])`),
- a trailing splat capturing multiple args,
- a splat capturing zero args,
- splat elements preserving their original (nested) exprs,
- a leading splat before a fixed trailing argument, and
- exact-arity rejection when no splat is present.

Full suite passes locally (`data 267`, `match 96`, `derive 6`).

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)