### PR TITLE
fix(match): make isa_variant fallback return false for non-ADT values

### DIFF
--- a/src/data/runtime.jl
+++ b/src/data/runtime.jl
@@ -180,9 +180,14 @@ end
 $DEF
 
 Check if the given variant is an instance of the given variant type.
+
+The fallback returns `false`: if `x` is not an instance of the algebraic data
+type that owns `variant` (e.g. an unrelated value such as `nothing`), then it is
+not an instance of `variant`. This lets `@match` fall through to a wildcard arm
+instead of erroring on values that are not the expected data type.
 """
 @pub function isa_variant(x, variant::Type)::Bool
-    throw(IllegalDispatch("got $(typeof(x)) for $variant"))
+    return false
 end
 
 """

--- a/test/match/examples/data.jl
+++ b/test/match/examples/data.jl
@@ -52,3 +52,24 @@ end
     @test foo(Message.Write("aaa")) == "aaa"
     @test foo(Message.ChangeColor(1, 2, 3)) == 1
 end # testset
+
+@data ADT begin
+    A
+    B
+end
+
+# https://github.com/Roger-luo/Moshi.jl/issues/43
+# matching a value that is not the ADT should fall through to the wildcard
+# instead of throwing IllegalDispatch.
+is_a(x) = @match x begin
+    ADT.A() => true
+    _ => false
+end
+
+@testset "wildcard matches non-ADT value (#43)" begin
+    @test is_a(ADT.A()) == true
+    @test is_a(ADT.B()) == false
+    @test is_a(nothing) == false
+    @test is_a(1) == false
+    @test is_a("string") == false
+end # testset


### PR DESCRIPTION
## Summary

Fixes #43.

Matching a value that is *not* the expected ADT against a variant pattern threw `IllegalDispatch` instead of falling through to the wildcard arm:

```julia
@data ADT begin
    A
    B
end

is_a(x) = @match x begin
    ADT.A() => true
    _ => false
end

is_a(ADT.A())   # true
is_a(ADT.B())   # false
is_a(nothing)   # ERROR: illegal dispatch, expect to be overloaded by @data
```

## Root cause

`@match` compiles a `Variant() => ...` arm into a `Data.isa_variant(value, Variant)` call. `@data` generates `isa_variant` methods that dispatch on the wrapper type (`ADT.Type`), so passing an unrelated value (e.g. `nothing`) hit the runtime fallback in `src/data/runtime.jl`, which threw `IllegalDispatch`.

## Fix

`isa_variant` is a boolean predicate: if `x` is not an instance of the ADT owning `variant`, it is not an instance of `variant`, so the fallback now returns `false`. This lets `@match` fall through to the wildcard arm. The other reflection functions (which are genuinely partial) keep throwing `IllegalDispatch`.

## Testing

- Added a regression testset in `test/match/examples/data.jl` covering `nothing`, `Int`, and `String` against a variant pattern with a wildcard.
- Full suite passes: `data 267/267`, `match 95/95`, `derive 6/6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)