### PR TITLE
chore: format repo with JuliaFormatter (blue style)

### DIFF
--- a/src/data/cons.jl
+++ b/src/data/cons.jl
@@ -1,15 +1,20 @@
 function _is_doc_macro(head)
     head === Symbol("@doc") && return true
-    head isa GlobalRef && head.name === Symbol("@doc") &&
-        (head.mod === Core || head.mod === Base) && return true
+    head isa GlobalRef &&
+        head.name === Symbol("@doc") &&
+        (head.mod === Core || head.mod === Base) &&
+        return true
     return false
 end
 
 function push_variants!(variants::Vector{Variant}, expr, doc, source)
     if Meta.isexpr(expr, :macrocall) && _is_doc_macro(expr.args[1])
         non_lnn = filter(a -> !(a isa LineNumberNode), expr.args)
-        length(non_lnn) == 3 ||
-            throw(ArgumentError("malformed @doc in @data body: expected `@doc <docstring> <variant>`, got: $expr"))
+        length(non_lnn) == 3 || throw(
+            ArgumentError(
+                "malformed @doc in @data body: expected `@doc <docstring> <variant>`, got: $expr",
+            ),
+        )
         _, doc, variant_expr = non_lnn
         lnn_idx = findfirst(a -> a isa LineNumberNode, expr.args)
         doc_source = isnothing(lnn_idx) ? source : expr.args[lnn_idx]
@@ -17,8 +22,11 @@ function push_variants!(variants::Vector{Variant}, expr, doc, source)
         return nothing
     end
     if Meta.isexpr(expr, :block)
-        isnothing(doc) ||
-            throw(ArgumentError("@doc cannot be applied to a block; place `@doc` before each variant individually"))
+        isnothing(doc) || throw(
+            ArgumentError(
+                "@doc cannot be applied to a block; place `@doc` before each variant individually",
+            ),
+        )
         for arg in expr.args
             if arg isa LineNumberNode
                 source = arg
@@ -33,7 +41,9 @@ function push_variants!(variants::Vector{Variant}, expr, doc, source)
 end
 
 # concrete
-function TypeDef(mod::Module, ismutable::Bool, head, body::Expr; source::LineNumberNode=LineNumberNode(0))
+function TypeDef(
+    mod::Module, ismutable::Bool, head, body::Expr; source::LineNumberNode=LineNumberNode(0)
+)
     head = TypeHead(head)
     Meta.isexpr(body, :block) ||
         throw(ArgumentError("expect begin ... end block, got $body"))

--- a/src/data/emit/cons.jl
+++ b/src/data/emit/cons.jl
@@ -9,7 +9,7 @@ function emit_each_variant_cons(info::EmitInfo, storage::StorageInfo)
         [Symbol(i) for i in 1:length(storage.parent.fields)]
     else
         map(storage.parent.fields) do field::NamedField
-            field.name
+            return field.name
         end
     end
 
@@ -126,18 +126,17 @@ end
 function emit_each_variant_doc(info::EmitInfo, storage::StorageInfo)
     isnothing(storage.parent.doc) && return nothing
     raw = storage.parent.doc
-    raw isa String || Meta.isexpr(raw, :macrocall) ||
-        throw(ArgumentError(
-            "variant doc for $(storage.parent.name) must be a string literal or macro call, got: $(typeof(raw))"
-        ))
+    raw isa String ||
+        Meta.isexpr(raw, :macrocall) ||
+        throw(
+            ArgumentError(
+                "variant doc for $(storage.parent.name) must be a string literal or macro call, got: $(typeof(raw))",
+            ),
+        )
     source = something(storage.parent.source, info.def.source)
     doc = eval_global_ref(info.def.mod, raw)
     return Expr(
-        :macrocall,
-        GlobalRef(Base, Symbol("@doc")),
-        source,
-        doc,
-        storage.parent.name,
+        :macrocall, GlobalRef(Base, Symbol("@doc")), source, doc, storage.parent.name
     )
 end
 

--- a/src/data/emit/getproperty.jl
+++ b/src/data/emit/getproperty.jl
@@ -69,9 +69,7 @@ end
 
     if isempty(info.params)
         return quote
-            $Base.@inline function $Base.getproperty(
-                value::Type, index::Int
-            )
+            $Base.@inline function $Base.getproperty(value::Type, index::Int)
                 data = $Base.getfield(value, :data)
                 return $(codegen_ast(jl))
             end

--- a/src/data/emit/reflect.jl
+++ b/src/data/emit/reflect.jl
@@ -259,7 +259,7 @@ function emit_variant_fieldtypes_each_storage(info::EmitInfo, storage::StorageIn
     else
         # assign type params to Any
         assign_any = expr_map(info.params) do param
-            :($param = Any)
+            return :($param = Any)
         end
 
         return quote
@@ -290,7 +290,9 @@ end
         end
 
         return quote
-            $Base.@inline function $Data.variant_fieldnames(::$Type{<:$(storage.parent.name)})
+            $Base.@inline function $Data.variant_fieldnames(
+                ::$Type{<:$(storage.parent.name)}
+            )
                 return $(fieldnames)
             end
         end
@@ -342,9 +344,7 @@ end
 
         return quote
             $Base.@inline function $Data.variant_getfield(
-                value::$(info.type_head),
-                tag::$Type{$(storage.parent.name)},
-                field::Symbol,
+                value::$(info.type_head), tag::$Type{$(storage.parent.name)}, field::Symbol
             ) where {$(info.whereparams...)}
                 data = $Base.getfield(value, :data)::$(storage.head)
                 return $body

--- a/src/data/emit/setproperty.jl
+++ b/src/data/emit/setproperty.jl
@@ -36,7 +36,7 @@
 
     return quote
         $Base.@inline function $Base.setproperty!(
-            value::$(info.type_head), name::Symbol, new_value,
+            value::$(info.type_head), name::Symbol, new_value
         ) where {$(info.whereparams...)}
             data = $Base.getfield(value, :data)
             return $(codegen_ast(jl))
@@ -75,9 +75,7 @@ end
 
     if isempty(info.params)
         return quote
-            $Base.@inline function $Base.setproperty!(
-                value::Type, index::Int, new_value
-            )
+            $Base.@inline function $Base.setproperty!(value::Type, index::Int, new_value)
                 data = $Base.getfield(value, :data)
                 return $(codegen_ast(jl))
             end

--- a/src/data/emit/storage.jl
+++ b/src/data/emit/storage.jl
@@ -16,13 +16,27 @@ function emit_each_variant_storage(info::EmitInfo, storage::StorageInfo)
                 name=gensym(:field), type=storage.types[i], line=storage.parent.source
             ) for (i, field) in enumerate(storage.parent.fields)
         ]
-        JLStruct(; typevars=info.whereparams, name=storage.name, fields, ismutable=info.def.ismutable)
+        JLStruct(;
+            typevars=info.whereparams,
+            name=storage.name,
+            fields,
+            ismutable=info.def.ismutable,
+        )
     else
         fields = [
-            JLField(; name=field.name, type=storage.types[i], line=field.source, isconst=field.isconst) for
-            (i, field) in enumerate(storage.parent.fields)
+            JLField(;
+                name=field.name,
+                type=storage.types[i],
+                line=field.source,
+                isconst=field.isconst,
+            ) for (i, field) in enumerate(storage.parent.fields)
         ]
-        JLStruct(; typevars=info.whereparams, name=storage.name, fields, ismutable=info.def.ismutable)
+        JLStruct(;
+            typevars=info.whereparams,
+            name=storage.name,
+            fields,
+            ismutable=info.def.ismutable,
+        )
     end
     return codegen_ast(jl)
 end

--- a/src/data/emit/type.jl
+++ b/src/data/emit/type.jl
@@ -7,10 +7,18 @@
 
     jl = JLStruct(;
         name=Symbol("typeof($(info.def.head.name))"),
-        fields=[JLField(; name=:data, type=:(Union{$(union_params...)}), isconst = info.def.ismutable)],
+        fields=[
+            JLField(;
+                name=:data, type=:(Union{$(union_params...)}), isconst=info.def.ismutable
+            ),
+        ],
         typevars=info.whereparams,
-	supertype=isnothing(info.def.head.supertype) ? nothing : guess_self_as_any(info.def, info.def.head.supertype),
-	    ismutable = info.def.ismutable,
+        supertype=if isnothing(info.def.head.supertype)
+            nothing
+        else
+            guess_self_as_any(info.def, info.def.head.supertype)
+        end,
+        ismutable=info.def.ismutable,
     )
 
     binding = if isempty(info.params)

--- a/src/data/runtime.jl
+++ b/src/data/runtime.jl
@@ -206,7 +206,7 @@ Base.@assume_effects :foldable @inline function convert_singleton_bottom(
 end
 
 function convert_singleton_bottom_generated(::Type, x)
-    throw(IllegalDispatch())
+    return throw(IllegalDispatch())
 end
 
 """

--- a/src/data/scan.jl
+++ b/src/data/scan.jl
@@ -45,14 +45,14 @@ function guess_self_as_any(def::TypeDef, expr)
         type === Any && return Any # no need to guess further
 
         typevars = map(expr.args[2:end]) do param
-            guess_self_as_any(def, param)
+            return guess_self_as_any(def, param)
         end
         Any in typevars && return Any # no need to specialize further
         return :($type{$(typevars...)})
     elseif Meta.isexpr(expr, :call)
         fn = guess_self_as_any(def, expr.args[1])
         args = map(expr.args[2:end]) do arg
-            guess_self_as_any(def, arg)
+            return guess_self_as_any(def, arg)
         end
         return :($fn($(args...)))
     else
@@ -79,13 +79,13 @@ function guess_self_as_annotation(def::TypeDef, expr)
         type = guess_self_as_annotation(def, expr.args[1])
 
         typevars = map(expr.args[2:end]) do param
-            guess_self_as_annotation(def, param)
+            return guess_self_as_annotation(def, param)
         end
         return :($type{$(typevars...)})
     elseif Meta.isexpr(expr, :call)
         fn = guess_self_as_annotation(def, expr.args[1])
         args = map(expr.args[2:end]) do arg
-            guess_self_as_annotation(def, arg)
+            return guess_self_as_annotation(def, arg)
         end
         return :($fn($(args...)))
     else
@@ -111,7 +111,11 @@ function EmitInfo(def::TypeDef)
         elseif isnothing(var.ub)
             :($(var.name) >: $(guess_type(def.mod, var.lb)))
         else
-            :($(guess_type(def.mod, var.lb)) <: $(var.name) <: $(guess_type(def.mod, var.ub)))
+            :(
+                $(guess_type(def.mod, var.lb)) <:
+                $(var.name) <:
+                $(guess_type(def.mod, var.ub))
+            )
         end
     end
 

--- a/src/derive/eq.jl
+++ b/src/derive/eq.jl
@@ -40,7 +40,7 @@ end
 
 function eq_derive_variant_field(func, variant_type)
     cache_indices = findall(Data.variant_fieldtypes(variant_type)) do type
-        type <: Hash.Cache
+        return type <: Hash.Cache
     end
     length(cache_indices) > 1 && error("Only one field of type Hash.Cache is allowed")
 

--- a/src/derive/mod.jl
+++ b/src/derive/mod.jl
@@ -29,7 +29,7 @@ function derive_m(mod::Module, expr)
     type isa Module || type isa DataType || error("expected a type")
 
     return expr_map(traits) do trait
-        derive_impl(Val(trait), mod, type)
+        return derive_impl(Val(trait), mod, type)
     end
 end
 

--- a/src/match/emit/call.jl
+++ b/src/match/emit/call.jl
@@ -27,21 +27,21 @@ function decons_call(head::Type, ctx::PatternContext, pat::Pattern.Type)
 
         args_conds = mapfoldl(and_expr, enumerate(pat.args); init=true) do (idx, x)
             call_ex = :($Data.variant_getfield($value, $head, $idx))
-            decons(ctx, x)(call_ex)
+            return decons(ctx, x)(call_ex)
         end
         kwargs_conds = mapfoldl(and_expr, pat.kwargs; init=true) do kw
             key, val = kw
             call_ex = :($Data.variant_getfield($value, $head, $(QuoteNode(key))))
-            decons(ctx, val)(call_ex)
+            return decons(ctx, val)(call_ex)
         end
     else # if isconcretetype(head)
         type_assert = :($value isa $head)
         args_conds = mapfoldl(and_expr, enumerate(pat.args); init=true) do (idx, x)
-            decons(ctx, x)(:($Core.getfield($value, $idx)))
+            return decons(ctx, x)(:($Core.getfield($value, $idx)))
         end
         kwargs_conds = mapfoldl(and_expr, pat.kwargs; init=true) do kw
             key, val = kw
-            decons(ctx, val)(:($Core.getfield($value, $key)))
+            return decons(ctx, val)(:($Core.getfield($value, $key)))
         end
     end
 

--- a/src/match/emit/collection/tuple.jl
+++ b/src/match/emit/collection/tuple.jl
@@ -8,7 +8,7 @@ function decons(::Type{Pattern.Tuple}, ctx::PatternContext, pat::Pattern.Type)
     end
     set_view_type_check!(coll) do view, eltype
         @gensym N
-        :($view isa $Base.NTuple{$N,$eltype} where {$N})
+        return :($view isa $Base.NTuple{$N,$eltype} where {$N})
     end
     return coll
 end

--- a/src/match/emit/collection/vect.jl
+++ b/src/match/emit/collection/vect.jl
@@ -9,7 +9,7 @@ function decons(::Type{Pattern.Ref}, ctx::PatternContext, pat::Pattern.Type)
     #    value.
     # 2 is not supported for now because I don't see any use case.
     coll = CollectionDecons(ctx, pat, pat.args) do _
-        :($Base.Vector{$(pat.head)})
+        return :($Base.Vector{$(pat.head)})
     end
     set_view_type_check!(coll) do view, eltype
         # For the pattern `AP[_, v::VP..., _]` matching a vector `A[_, V[...]..., _]`,
@@ -29,13 +29,15 @@ end
 
 function decons(::Type{Pattern.Vector}, ctx::PatternContext, pat::Pattern.Type)
     coll = CollectionDecons(ctx, pat, pat.xs) do _
-        :($Base.Vector)
+        return :($Base.Vector)
     end
     set_view_type_check!(coll) do view, eltype
         # The view shares the parent's (possibly abstract) `eltype`, so a bare
         # `eltype(view) == VP` never matches a more specific element type. Fall back to
         # checking each element when the static `eltype` is not already a subtype.
-        :($Base.eltype($view) <: $eltype || $Base.all($Base.Fix2(isa, $eltype), $view))
+        return :(
+            $Base.eltype($view) <: $eltype || $Base.all($Base.Fix2(isa, $eltype), $view)
+        )
     end
     return coll
 end

--- a/src/match/emit/ctx.jl
+++ b/src/match/emit/ctx.jl
@@ -41,7 +41,7 @@ end
 
 function emit_bind_match_values(ctx::PatternContext)
     return map(collect(keys(ctx.scope))) do k
-        :($k = $(first(ctx.scope[k])))
+        return :($k = $(first(ctx.scope[k])))
     end
 end
 

--- a/src/match/emit/entry.jl
+++ b/src/match/emit/entry.jl
@@ -8,7 +8,7 @@ function emit(info::EmitInfo)
         end
 
         cond = decons(ctx, case)(info.value_holder)
-        maybe_if(
+        return maybe_if(
             and_expr(cond, emit_check_duplicated_variables(ctx)),
             Expr(
                 :block,

--- a/src/match/emit/expr.jl
+++ b/src/match/emit/expr.jl
@@ -5,10 +5,12 @@ function decons(::Type{Pattern.Expression}, ctx::PatternContext, pat::Pattern.Ty
         # (e.g. `:($f($arg0, $(args...)))`) and an exact length check for free,
         # matching the semantics of the `[...]` and `(...)` patterns.
         coll = CollectionDecons(ctx, pat, pat.args) do _
-            :($Base.Vector)
+            return :($Base.Vector)
         end
         set_view_type_check!(coll) do view, eltype
-            :($Base.eltype($view) <: $eltype || $Base.all($Base.Fix2(isa, $eltype), $view))
+            return :(
+                $Base.eltype($view) <: $eltype || $Base.all($Base.Fix2(isa, $eltype), $view)
+            )
         end
         return and_expr(
             :($value isa Expr),

--- a/test/data/cons.jl
+++ b/test/data/cons.jl
@@ -140,7 +140,13 @@ end # Variant(Named)
 
 @testset "_is_doc_macro GlobalRef form" begin
     # GlobalRef(Core, :@doc) is an alternative head form _is_doc_macro must handle
-    expr = Expr(:macrocall, GlobalRef(Core, Symbol("@doc")), LineNumberNode(1, :none), "CoreDoc", :Foo)
+    expr = Expr(
+        :macrocall,
+        GlobalRef(Core, Symbol("@doc")),
+        LineNumberNode(1, :none),
+        "CoreDoc",
+        :Foo,
+    )
     def = TypeDef(Main, false, :TestCoreDoc, Expr(:block, expr))
     @test length(def.variants) == 1
     @test def.variants[1].name == :Foo

--- a/test/data/emit/basic.jl
+++ b/test/data/emit/basic.jl
@@ -238,4 +238,3 @@ end
 
     @test variant_name(MutableMessage.Move) == :Move
 end # MutableMessage
-

--- a/test/data/emit/docs.jl
+++ b/test/data/emit/docs.jl
@@ -1,6 +1,6 @@
 using Test
 using Moshi.Data: @data, variants
-import Markdown
+using Markdown: Markdown
 
 # Homegrown doc macro: wraps text in a tagged string so we can detect it.
 macro customdoc_str(s)
@@ -95,8 +95,12 @@ end
     @test doc_text(DocTest, :PlainStringFields) == "plain string, with fields"
     @test doc_text(DocTest, :PlainStringSingleton) == "plain string, no fields"
     @test doc_text(DocTest, :NamedWithDoc) == "named struct doc"
-    @test occursin("explicit doc markdown, with fields", doc_text(DocTest, :ExplicitMarkdownFields))
-    @test occursin("explicit doc markdown, no fields", doc_text(DocTest, :ExplicitMarkdownSingleton))
+    @test occursin(
+        "explicit doc markdown, with fields", doc_text(DocTest, :ExplicitMarkdownFields)
+    )
+    @test occursin(
+        "explicit doc markdown, no fields", doc_text(DocTest, :ExplicitMarkdownSingleton)
+    )
 end
 
 @testset "custom doc macro" begin

--- a/test/data/show.jl
+++ b/test/data/show.jl
@@ -1,7 +1,7 @@
 using Test
 using ExproniconLite: @expr, no_default
 using Moshi.Data: Variant, Singleton, Named, Anonymous, Field, NamedField, TypeHead, TypeDef
-import Markdown
+using Markdown: Markdown
 
 ex = quote
     """
@@ -48,23 +48,25 @@ function show_variant(def, i)
 end
 
 @testset "docstring rendering" begin
-    string_def = TypeDef(Main, false, :ShowDocTest, quote
-        "plain string doc"
-        PlainSingleton
+    string_def = TypeDef(
+        Main, false, :ShowDocTest, quote
+            "plain string doc"
+            PlainSingleton
 
-        "plain string doc"
-        PlainFields(Int, Float32)
+            "plain string doc"
+            PlainFields(Int, Float32)
 
-        @doc Markdown.doc"""
-        markdown doc
-        """
-        MarkdownSingleton
+            @doc Markdown.doc"""
+            markdown doc
+            """
+            MarkdownSingleton
 
-        @doc Markdown.doc"""
-        markdown doc
-        """
-        MarkdownFields(Int, Float32)
-    end)
+            @doc Markdown.doc"""
+            markdown doc
+            """
+            MarkdownFields(Int, Float32)
+        end
+    )
 
     @test contains(show_variant(string_def, 1), "plain string doc")
     @test contains(show_variant(string_def, 2), "plain string doc")


### PR DESCRIPTION
## Summary

Runs `JuliaFormatter.format` over `src` and `test` to bring the entire tree in line with the repo's blue style (`.JuliaFormatter.toml`). The formatter version had drifted from what the repo was last formatted with, leaving cosmetic inconsistencies scattered across the codebase.

**Cosmetic only** — no behavior changes. Diffs are limited to:
- adding explicit `return` on trailing expressions (blue style)
- wrapping/collapsing long call signatures
- trailing-newline normalization

## Testing

- `JuliaFormatter` v2.10.1, `style = "blue"`.
- Full suite passes: `data 267/267`, `match 103/103`, `derive 6/6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)