### PR TITLE
fix(data): promote parametric singletons in variant constructors

### DIFF
--- a/src/data/emit/cons.jl
+++ b/src/data/emit/cons.jl
@@ -75,18 +75,69 @@ function emit_each_variant_cons_inferred(info::EmitInfo, storage::StorageInfo)
 
     is_inferrable(info.params, storage) || return nothing
 
-    if storage.parent.kind == Anonymous
-        args = [:($(Symbol(i))::$(type)) for (i, type) in enumerate(storage.annotations)]
-        inputs = [Symbol(i) for i in 1:length(storage.parent.fields)]
+    names = if storage.parent.kind == Anonymous
+        [Symbol(i) for i in 1:length(storage.parent.fields)]
     else
-        args = [
-            :($(field.name)::$(type)) for
-            (field, type) in zip(storage.parent.fields, storage.annotations)
-        ]
-        inputs = [field.name for field in storage.parent.fields]
+        [field.name for field in storage.parent.fields]
     end
 
-    jl = JLFunction(;
+    # The "promoting" constructor additionally accepts a parametric singleton
+    # bottom (e.g. `Tree.Empty()::Tree.Type{Union{}}`) in self-referential field
+    # positions and converts it to the resolved `Tree.Type{T}` before storing, so
+    # `Tree.Node(5, Tree.Leaf(3), Tree.Empty())` works instead of erroring on a
+    # type parameter mismatch. See issue #34.
+    selfrefs = findall(is_self_ref_annotation, storage.annotations)
+    isempty(selfrefs) && return codegen_ast(exact_variant_cons(info, storage, names))
+
+    promoting = codegen_ast(promoting_variant_cons(info, storage, names))
+    # When the promoting constructor is not strictly more general than the exact
+    # one, their method signatures coincide and defining both would overwrite (and
+    # warn). This happens unless some argument can pin the type parameters while a
+    # self-reference is left as the bottom — i.e. there are multiple self-refs, or
+    # a non-self-ref field mentions a type parameter.
+    others_pin = any(eachindex(storage.annotations)) do i
+        i in selfrefs && return false
+        return any(is_inferrable(param, storage.annotations[i]) for param in info.params)
+    end
+    if length(selfrefs) >= 2 || others_pin
+        return Expr(
+            :block, codegen_ast(exact_variant_cons(info, storage, names)), promoting
+        )
+    else
+        return promoting
+    end
+end
+
+function exact_variant_cons(info::EmitInfo, storage::StorageInfo, names)
+    args = [:($(name)::$(type)) for (name, type) in zip(names, storage.annotations)]
+    return JLFunction(;
+        name=storage.parent.name,
+        args,
+        info.whereparams,
+        body=quote
+            $(Expr(:meta, :inline))
+            return $(info.type_head)($(storage.head)($(names...)))
+        end,
+    )
+end
+
+function promoting_variant_cons(info::EmitInfo, storage::StorageInfo, names)
+    bottom = :(Type{$([:(Union{}) for _ in info.params]...)})
+    args = [
+        if is_self_ref_annotation(type)
+            :($(name)::Union{$(type),$(bottom)})
+        else
+            :($(name)::$(type))
+        end for (name, type) in zip(names, storage.annotations)
+    ]
+    inputs = [
+        if is_self_ref_annotation(type)
+            :($Base.convert($(type), $(name)))
+        else
+            name
+        end for (name, type) in zip(names, storage.annotations)
+    ]
+    return JLFunction(;
         name=storage.parent.name,
         args,
         info.whereparams,
@@ -95,9 +146,11 @@ function emit_each_variant_cons_inferred(info::EmitInfo, storage::StorageInfo)
             return $(info.type_head)($(storage.head)($(inputs...)))
         end,
     )
-
-    return codegen_ast(jl)
 end
+
+# A field annotation is a parametric self-reference (e.g. `Tree.Type{T}`) when it
+# is a `:curly` expression headed by the ADT's own `Type` alias.
+is_self_ref_annotation(type) = Meta.isexpr(type, :curly) && type.args[1] === :Type
 
 function is_inferrable(params::Vector{Symbol}, storage::StorageInfo)
     return all(is_inferrable(param, storage) for param in params)

--- a/test/data/emit/mod.jl
+++ b/test/data/emit/mod.jl
@@ -12,6 +12,7 @@ end
     include("uninferable.jl")
     include("named.jl")
     include("call_type.jl")
+    include("singleton_promote.jl")
 end
 
 module TestCons

--- a/test/data/emit/singleton_promote.jl
+++ b/test/data/emit/singleton_promote.jl
@@ -1,0 +1,65 @@
+# Regression tests for issue #34: a parametric singleton such as `Tree.Empty()`
+# has type `Tree.Type{Union{}}` and must be promoted to the resolved element type
+# when used as a self-referential argument of another variant constructor.
+module TestSingletonPromote
+using Test
+using Moshi.Data: @data, isa_variant, variant_getfield
+
+@data Tree{T} begin
+    Empty
+    Leaf(T)
+    Node(T, Tree{T}, Tree{T})
+end
+
+@testset "issue #34: singleton promotion in constructors" begin
+    @testset "mixed singleton / concrete children" begin
+        @test typeof(Tree.Node(5, Tree.Leaf(3), Tree.Empty())) == Tree.Type{Int}
+        @test typeof(Tree.Node(5, Tree.Empty(), Tree.Leaf(3))) == Tree.Type{Int}
+        @test typeof(Tree.Node(5, Tree.Empty(), Tree.Empty())) == Tree.Type{Int}
+    end
+
+    @testset "homogeneous children (no promotion needed)" begin
+        @test typeof(Tree.Node(5, Tree.Leaf(1), Tree.Leaf(2))) == Tree.Type{Int}
+    end
+
+    @testset "explicit type parameter still works" begin
+        @test typeof(Tree.Node(5, Tree.Leaf(3), Tree.Empty{Int}())) == Tree.Type{Int}
+    end
+
+    @testset "promoted child is stored as the resolved type" begin
+        t = Tree.Node(5, Tree.Empty(), Tree.Leaf(3))
+        left = variant_getfield(t, Tree.Node, 2)
+        @test left isa Tree.Type{Int}
+        @test isa_variant(left, Tree.Empty)
+    end
+
+    @testset "nested construction" begin
+        big = Tree.Node(1, Tree.Node(2, Tree.Empty(), Tree.Leaf(3)), Tree.Empty())
+        @test typeof(big) == Tree.Type{Int}
+    end
+
+    @testset "genuine type mismatch still errors" begin
+        @test_throws MethodError Tree.Node(5, Tree.Leaf(3.0), Tree.Empty())
+    end
+
+    @testset "construction is type stable" begin
+        f() = Tree.Node(5, Tree.Leaf(3), Tree.Empty())
+        rt = Base.return_types(f, Tuple{})[1]
+        @test rt == Tree.Type{Int}
+        @test isconcretetype(rt)
+    end
+end
+
+# A variant whose only fields are self-references: the all-bottom call must still
+# resolve (to `Union{}`), while a mixed call promotes to the concrete type.
+@data Lst{T} begin
+    Nil
+    Cons(Lst{T}, Lst{T})
+end
+
+@testset "issue #34: self-referential-only variant" begin
+    @test typeof(Lst.Cons(Lst.Nil(), Lst.Nil())) == Lst.Type{Union{}}
+    @test typeof(Lst.Cons(Lst.Cons(Lst.Nil(), Lst.Nil()), Lst.Nil())) == Lst.Type{Union{}}
+end
+
+end # module TestSingletonPromote


### PR DESCRIPTION
Fixes #34.

## Problem

For a parametric ADT, a singleton constructor like `Tree.Empty()` produces a value of type `Tree.Type{Union{}}` (the singleton "bottom" default). The generated variant constructor is an exact-match method:

```julia
Node(::T, ::Tree.Type{T}, ::Tree.Type{T}) where {T}
```

So the natural call from the issue fails to dispatch, because `T` is pinned to `Int` by the other arguments while `Tree.Empty()` is `Tree.Type{Union{}}` (Julia type parameters are invariant, so `Tree.Type{Union{}} <: Tree.Type{Int}` does not hold):

```julia
julia> Tree.Node(5, Tree.Leaf(3), Tree.Empty())
ERROR: MethodError: no method matching Node(::Int64, ::Tree.Type{Int64}, ::Tree.Type{Union{}})
```

Users had to spell out the type parameter explicitly (`Tree.Empty{Int}()`), as noted in the issue thread.

## Fix

A `Base.convert` method that promotes `Tree.Type{Union{}} → Tree.Type{T}` already exists (it's what makes return-type annotations like `f(...)::Tree.Type{Int}` work), but the constructors never used it.

The inferred constructor now also emits a **promoting** method that accepts a singleton bottom in self-referential field positions and `convert`s it to the resolved element type before storing:

```julia
Node(::T, ::Union{Tree.Type{T}, Tree.Type{Union{}}}, ::Union{Tree.Type{T}, Tree.Type{Union{}}}) where {T}
```

Notes on the design:

- The more-specific **exact** method still wins for homogeneous calls, so there's no conversion overhead when it isn't needed.
- The exact method is emitted **only when it is genuinely distinct** from the promoting one. For a variant whose sole field is a self-reference (e.g. `Ref(SelfRef{T})`), the two signatures coincide, so only the promoting method is emitted — avoiding a method-overwrite warning at definition time.
- The self-referential-only, all-bottom case (`Cons(Nil(), Nil())`) still resolves to `T = Union{}` via the exact method.
- Genuine type mismatches (`Node(5, Leaf(3.0), Empty())`) still raise a `MethodError`.
- Construction remains type stable (`Tree.Type{Int}`, a concrete type).

## Verification

The issue's exact example now works:

```julia
julia> Tree.Node(5, Tree.Leaf(3), Tree.Empty())
# => Tree.Type{Int64}
```

- Added `test/data/emit/singleton_promote.jl` covering mixed/homogeneous/nested construction, promoted-child storage, type stability, mismatch errors, and self-referential-only variants.
- Full suite passes (`data` 267 → 280 with the new tests, `match` 103, `derive` 6), with no method-overwrite warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)