### PR TITLE
fix(data): convert constructor arguments to declared field types

### DIFF
--- a/src/data/emit/cons.jl
+++ b/src/data/emit/cons.jl
@@ -13,12 +13,21 @@ function emit_each_variant_cons(info::EmitInfo, storage::StorageInfo)
         end
     end
 
+    # Storage struct fields use `Any` whenever the declared type collapses (e.g. a
+    # `Vector{Any}` field or a self-referential `Vector{Self}`), so Julia's inner
+    # constructor performs no conversion. Convert each argument to its declared
+    # annotation type here to restore normal struct semantics; otherwise the value
+    # stored can mismatch the type assert in `getproperty`/`variant_getfield`. See #32.
+    inputs = [
+        :($Base.convert($(type), $(arg))) for (arg, type) in zip(args, storage.annotations)
+    ]
+
     return quote
         $Base.@constprop :aggressive function $(storage.variant_head)(
             $(args...)
         ) where {$(info.whereparams...)}
             $(Expr(:meta, :inline))
-            return $(info.type_head)($(storage.head)($(args...)))
+            return $(info.type_head)($(storage.head)($(inputs...)))
         end
     end
 end
@@ -34,6 +43,11 @@ function emit_each_variant_kw_cons(info::EmitInfo, storage::StorageInfo)
     isempty(storage.parent.fields) && return nothing
 
     args = [field.name for field in storage.parent.fields]
+    # See `emit_each_variant_cons`: convert to the declared field types so the
+    # stored value matches the annotation used by `getproperty`. See #32.
+    inputs = [
+        :($Base.convert($(type), $(arg))) for (arg, type) in zip(args, storage.annotations)
+    ]
     jl = JLFunction(;
         name=storage.variant_head,
         kwargs=[
@@ -46,7 +60,7 @@ function emit_each_variant_kw_cons(info::EmitInfo, storage::StorageInfo)
         info.whereparams,
         body=quote
             $(Expr(:meta, :inline))
-            return $(info.type_head)($(storage.head)($(args...)))
+            return $(info.type_head)($(storage.head)($(inputs...)))
         end,
     )
 

--- a/test/data/emit/container.jl
+++ b/test/data/emit/container.jl
@@ -1,0 +1,108 @@
+# Regression tests for issue #32: a field whose declared type collapses to `Any`
+# in the storage struct (e.g. `Vector{Any}` or a self-referential `Vector{Self}`)
+# must still be converted to its declared type on construction, otherwise the type
+# assert in `getproperty`/`variant_getfield` fails.
+module TestContainerConvert
+using Test
+using Moshi.Data: @data, variant_fieldtypes, variant_getfield
+
+@data OptionVec{T} begin
+    None()
+    struct Some
+        n::T
+        xs::Vector{Any}
+    end
+end
+
+@data AnonVec begin
+    V(Vector{Any})
+end
+
+@data NamedVec begin
+    struct W
+        xs::Vector{Any}
+    end
+end
+
+@data KwVec begin
+    struct K
+        xs::Vector{Any} = Any[]
+    end
+end
+
+@testset "issue #32: Vector{Any} field converts on construction" begin
+    @testset "generic named variant, explicit type parameter" begin
+        a = OptionVec.Some{String}("hi", [1, 2])
+        @test a.xs == [1, 2]
+        @test a.xs isa Vector{Any}
+        @test variant_fieldtypes(a) == (String, Vector{Any})
+        @test a.n == "hi"
+    end
+
+    @testset "anonymous variant" begin
+        v = AnonVec.V([5])
+        @test getproperty(v, 1) == [5]
+        @test getproperty(v, 1) isa Vector{Any}
+        @test variant_getfield(v, AnonVec.V, 1) isa Vector{Any}
+    end
+
+    @testset "named variant, positional constructor" begin
+        w = NamedVec.W([1, 2, 3])
+        @test w.xs == [1, 2, 3]
+        @test w.xs isa Vector{Any}
+    end
+
+    @testset "keyword constructor" begin
+        @test KwVec.K(; xs=[1, 2]).xs isa Vector{Any}
+        @test KwVec.K([1, 2]).xs isa Vector{Any}
+        @test KwVec.K().xs == Any[]
+    end
+end
+
+# A self-referential container field (`Vector{Self}`) stores as `Any` in the
+# storage struct, so it also needs conversion so that e.g. an empty `Vector{Any}`
+# literal is stored as the resolved element type.
+@data Rose begin
+    struct Node
+        value::Int
+        children::Vector{Rose}
+    end
+end
+
+@data RoseP{T} begin
+    struct Node
+        value::T
+        children::Vector{RoseP{T}}
+    end
+end
+
+@testset "issue #32: self-referential Vector field converts" begin
+    leaf = Rose.Node(1, [])
+    @test leaf.children isa Vector{Rose.Type}
+    @test isempty(leaf.children)
+
+    tree = Rose.Node(0, [leaf])
+    @test tree.children isa Vector{Rose.Type}
+    @test tree.children[1].value == 1
+
+    p = RoseP.Node{Int}(0, [])
+    @test p.children isa Vector{RoseP.Type{Int}}
+end
+
+# Explicit-brace construction of a self-referential variant with a parametric
+# singleton bottom (`Empty()::Type{Union{}}`) must promote the child to the
+# resolved type before storing, matching the inferred constructor (issue #34).
+@data Tree{T} begin
+    Empty()
+    Leaf(T)
+    Node(T, Tree{T}, Tree{T})
+end
+
+@testset "issue #32: explicit-brace self-ref promotion" begin
+    n = Tree.Node{Int}(5, Tree.Leaf(3), Tree.Empty())
+    @test typeof(n) == Tree.Type{Int}
+    right = variant_getfield(n, Tree.Node, 3)
+    @test right isa Tree.Type{Int}
+end
+
+end # module TestContainerConvert

--- a/test/data/emit/mod.jl
+++ b/test/data/emit/mod.jl
@@ -13,6 +13,7 @@ end
     include("named.jl")
     include("call_type.jl")
     include("singleton_promote.jl")
+    include("container.jl")
 end
 
 module TestCons


### PR DESCRIPTION
## Summary

Fixes #32 — `TypeError` in `getproperty` on container-typed fields.

### Root cause

Variant storage structs use `Any` for a field whenever its declared type "collapses" in `guess_self_as_any` (`src/data/scan.jl`):

- **A genuine `Any` type parameter** — e.g. `Vector{Any}` becomes an `Any` storage field.
- **A self-referential container** — e.g. `Vector{Self}` must use `Any` because the wrapper `Type` isn't defined yet when the storage struct is emitted (removing the collapse, as suggested in the issue thread, breaks these).

Because the storage field is `Any`, Julia's inner constructor performs **no conversion**, so the stored value keeps its original type (`Vector{Int}`). But `getproperty`/`variant_getfield` type-assert against the *declared* annotation (`Vector{Any}`), producing:

```
ERROR: TypeError: in typeassert, expected Vector{Any}, got a value of type Vector{Int64}
```

### Fix

Convert each argument to its declared annotation type in the positional (`emit_each_variant_cons`) and keyword (`emit_each_variant_kw_cons`) constructors, restoring the normal Julia struct-construction semantics that were lost to the `Any` storage. The conversion is a no-op when the value already matches, so construction stays type stable (verified via `Base.return_types`).

This resolves all three failure modes from the issue:

- `OptionVec.Some{String}("hi", [1, 2])` (the report)
- `M.V([5])` (anonymous variant with `Vector{Any}`)
- `Pattern.Row([])` (self-referential `Vector{Self}`)

It also fixes a latent bug in the explicit-brace form of self-referential constructors: `Tree.Node{Int}(5, Tree.Leaf(3), Tree.Empty())` now promotes the parametric singleton bottom correctly.

### Not changed

The strict type-inferring constructor (`Some("hi", [1,2])` without `{String}`) still requires exact argument types — this is pre-existing behavior shared by all concrete field types (it also rejects `Int` for a `Float64` field), not the reported bug, and that path is deliberately delicate for type-parameter inference (see #34).

### Tests

Adds `test/data/emit/container.jl` covering generic/anonymous/named/keyword `Vector{Any}` fields, self-referential `Vector{Self}` conversion, and explicit-brace self-ref promotion. Full suite passes (data 285 → 304).

🤖 Generated with [Claude Code](https://claude.com/claude-code)