### PR TITLE
fix(data): convert self-referential container fields and defaults to declared types

### DIFF
--- a/docs/src/content/docs/data/syntax.mdx
+++ b/docs/src/content/docs/data/syntax.mdx
@@ -187,6 +187,27 @@ for example, the `Move` variant in the above example is a named variant.
 In the case of named fields, it supports `Base.@kwdef` syntax for default values.
 </Aside>
 
+<Aside type="tip" title="The ADT name refers to `.Type` inside the body">
+
+Everywhere inside the `@data` body — field types *and* default values — the bare
+ADT name refers to `<ident>.Type`. This makes self-referential defaults read
+naturally:
+
+```julia
+@data SExpr begin
+    struct Add
+        arguments::Vector{SExpr} = SExpr[]   # `SExpr` means `SExpr.Type`
+    end
+end
+
+SExpr.Add()  # arguments === SExpr.Type[]
+```
+
+Writing `SExpr.Type[]` explicitly is equivalent. See
+[issue #33](https://github.com/Roger-luo/Moshi.jl/issues/33).
+
+</Aside>
+
 ## Generics/Type Parameters
 
 The `@data` macro also supports defining algebraic data types with type parameters. For example:

--- a/src/data/emit/cons.jl
+++ b/src/data/emit/cons.jl
@@ -13,12 +13,21 @@ function emit_each_variant_cons(info::EmitInfo, storage::StorageInfo)
         end
     end
 
+    # Storage struct fields use `Any` whenever the declared type collapses (e.g. a
+    # `Vector{Any}` field or a self-referential `Vector{Self}`), so Julia's inner
+    # constructor performs no conversion. Convert each argument to its declared
+    # annotation type here to restore normal struct semantics; otherwise the value
+    # stored can mismatch the type assert in `getproperty`/`variant_getfield`. See #32.
+    inputs = [
+        :($Base.convert($(type), $(arg))) for (arg, type) in zip(args, storage.annotations)
+    ]
+
     return quote
         $Base.@constprop :aggressive function $(storage.variant_head)(
             $(args...)
         ) where {$(info.whereparams...)}
             $(Expr(:meta, :inline))
-            return $(info.type_head)($(storage.head)($(args...)))
+            return $(info.type_head)($(storage.head)($(inputs...)))
         end
     end
 end
@@ -34,6 +43,11 @@ function emit_each_variant_kw_cons(info::EmitInfo, storage::StorageInfo)
     isempty(storage.parent.fields) && return nothing
 
     args = [field.name for field in storage.parent.fields]
+    # See `emit_each_variant_cons`: convert to the declared field types so the
+    # stored value matches the annotation used by `getproperty`. See #32.
+    inputs = [
+        :($Base.convert($(type), $(arg))) for (arg, type) in zip(args, storage.annotations)
+    ]
     jl = JLFunction(;
         name=storage.variant_head,
         kwargs=[
@@ -46,7 +60,7 @@ function emit_each_variant_kw_cons(info::EmitInfo, storage::StorageInfo)
         info.whereparams,
         body=quote
             $(Expr(:meta, :inline))
-            return $(info.type_head)($(storage.head)($(args...)))
+            return $(info.type_head)($(storage.head)($(inputs...)))
         end,
     )
 

--- a/src/data/emit/cons.jl
+++ b/src/data/emit/cons.jl
@@ -54,7 +54,7 @@ function emit_each_variant_kw_cons(info::EmitInfo, storage::StorageInfo)
             if field.default === no_default
                 field.name
             else
-                Expr(:kw, field.name, eval_global_ref(info.def.mod, field.default))
+                Expr(:kw, field.name, eval_default(info.def, field.default))
             end for field in storage.parent.fields
         ],
         info.whereparams,
@@ -72,6 +72,50 @@ function eval_global_ref(mod::Module, expr)
         return GlobalRef(mod, expr)
     elseif expr isa Expr
         return Expr(expr.head, map(x -> eval_global_ref(mod, x), expr.args)...)
+    else
+        return expr
+    end
+end
+
+# Rewrite a variant field's default value for emission inside the generated module.
+#
+# A default may refer to the ADT itself by name, e.g.
+# `arguments::Vector{SExpr} = SExpr[]`. Inside the generated module the bare name
+# `SExpr` resolves to the *module*, not the type, so `SExpr[]` would expand to
+# `getindex(::Module)` and error. Like every other `SExpr` occurrence in the
+# `@data` block, the name should mean `SExpr.Type`; here we rewrite it (and its
+# explicit `SExpr.Type` / `SExpr{...}` forms) to the module-local `Type` alias.
+#
+# All other global symbols are resolved to a `GlobalRef` exactly like
+# `eval_global_ref`, so defaults keep referring to bindings from the module where
+# `@data` was written. Qualified access to the ADT module (e.g. `SExpr.Add`) is
+# preserved so variant constructors remain reachable. See issue #33.
+function eval_default(def::TypeDef, expr)
+    name = def.head.name
+    if expr isa Symbol
+        expr === name && return :Type
+        isdefined(def.mod, expr) && return GlobalRef(def.mod, expr)
+        return expr
+    elseif Meta.isexpr(expr, :.)
+        # explicit `SExpr.Type` self-reference => module-local `Type`
+        if expr.args[1] === name &&
+            expr.args[2] isa QuoteNode &&
+            expr.args[2].value === :Type
+            return :Type
+        end
+        # qualified access such as `SExpr.Add`: keep the base as the module itself
+        base = if expr.args[1] === name
+            GlobalRef(def.mod, name)
+        else
+            eval_default(def, expr.args[1])
+        end
+        return Expr(:., base, expr.args[2])
+    elseif Meta.isexpr(expr, :curly)
+        head = expr.args[1] === name ? :Type : eval_default(def, expr.args[1])
+        params = map(x -> eval_default(def, x), expr.args[2:end])
+        return Expr(:curly, head, params...)
+    elseif expr isa Expr
+        return Expr(expr.head, map(x -> eval_default(def, x), expr.args)...)
     else
         return expr
     end

--- a/test/data/emit/container.jl
+++ b/test/data/emit/container.jl
@@ -1,0 +1,108 @@
+# Regression tests for issue #32: a field whose declared type collapses to `Any`
+# in the storage struct (e.g. `Vector{Any}` or a self-referential `Vector{Self}`)
+# must still be converted to its declared type on construction, otherwise the type
+# assert in `getproperty`/`variant_getfield` fails.
+module TestContainerConvert
+using Test
+using Moshi.Data: @data, variant_fieldtypes, variant_getfield
+
+@data OptionVec{T} begin
+    None()
+    struct Some
+        n::T
+        xs::Vector{Any}
+    end
+end
+
+@data AnonVec begin
+    V(Vector{Any})
+end
+
+@data NamedVec begin
+    struct W
+        xs::Vector{Any}
+    end
+end
+
+@data KwVec begin
+    struct K
+        xs::Vector{Any} = Any[]
+    end
+end
+
+@testset "issue #32: Vector{Any} field converts on construction" begin
+    @testset "generic named variant, explicit type parameter" begin
+        a = OptionVec.Some{String}("hi", [1, 2])
+        @test a.xs == [1, 2]
+        @test a.xs isa Vector{Any}
+        @test variant_fieldtypes(a) == (String, Vector{Any})
+        @test a.n == "hi"
+    end
+
+    @testset "anonymous variant" begin
+        v = AnonVec.V([5])
+        @test getproperty(v, 1) == [5]
+        @test getproperty(v, 1) isa Vector{Any}
+        @test variant_getfield(v, AnonVec.V, 1) isa Vector{Any}
+    end
+
+    @testset "named variant, positional constructor" begin
+        w = NamedVec.W([1, 2, 3])
+        @test w.xs == [1, 2, 3]
+        @test w.xs isa Vector{Any}
+    end
+
+    @testset "keyword constructor" begin
+        @test KwVec.K(; xs=[1, 2]).xs isa Vector{Any}
+        @test KwVec.K([1, 2]).xs isa Vector{Any}
+        @test KwVec.K().xs == Any[]
+    end
+end
+
+# A self-referential container field (`Vector{Self}`) stores as `Any` in the
+# storage struct, so it also needs conversion so that e.g. an empty `Vector{Any}`
+# literal is stored as the resolved element type.
+@data Rose begin
+    struct Node
+        value::Int
+        children::Vector{Rose}
+    end
+end
+
+@data RoseP{T} begin
+    struct Node
+        value::T
+        children::Vector{RoseP{T}}
+    end
+end
+
+@testset "issue #32: self-referential Vector field converts" begin
+    leaf = Rose.Node(1, [])
+    @test leaf.children isa Vector{Rose.Type}
+    @test isempty(leaf.children)
+
+    tree = Rose.Node(0, [leaf])
+    @test tree.children isa Vector{Rose.Type}
+    @test tree.children[1].value == 1
+
+    p = RoseP.Node{Int}(0, [])
+    @test p.children isa Vector{RoseP.Type{Int}}
+end
+
+# Explicit-brace construction of a self-referential variant with a parametric
+# singleton bottom (`Empty()::Type{Union{}}`) must promote the child to the
+# resolved type before storing, matching the inferred constructor (issue #34).
+@data Tree{T} begin
+    Empty()
+    Leaf(T)
+    Node(T, Tree{T}, Tree{T})
+end
+
+@testset "issue #32: explicit-brace self-ref promotion" begin
+    n = Tree.Node{Int}(5, Tree.Leaf(3), Tree.Empty())
+    @test typeof(n) == Tree.Type{Int}
+    right = variant_getfield(n, Tree.Node, 3)
+    @test right isa Tree.Type{Int}
+end
+
+end # module TestContainerConvert

--- a/test/data/emit/mod.jl
+++ b/test/data/emit/mod.jl
@@ -13,6 +13,7 @@ end
     include("named.jl")
     include("call_type.jl")
     include("singleton_promote.jl")
+    include("container.jl")
 end
 
 module TestCons

--- a/test/data/emit/selfref.jl
+++ b/test/data/emit/selfref.jl
@@ -30,3 +30,39 @@ end
     y = SelfRef.Ref(SelfRef.Val(1))
     @test x == y
 end # selfref{T}
+
+# Issue #33: the ADT name in a default value should refer to `<Name>.Type`, just
+# like everywhere else in the `@data` block. `SExpr[]` must not resolve to the
+# generated module (which would error with `getindex(::Module)`).
+@data SExpr begin
+    struct Add
+        arguments::Vector{SExpr} = SExpr[]
+    end
+end
+
+# explicit `.Type` form is accepted and equivalent
+@data SExprExplicit begin
+    struct Add
+        arguments::Vector{SExprExplicit} = SExprExplicit.Type[]
+    end
+end
+
+@data SExprP{T} begin
+    struct Add
+        arguments::Vector{SExprP{T}} = SExprP{T}[]
+    end
+end
+
+@testset "issue #33: self-ref default values" begin
+    x = SExpr.Add()
+    @test x.arguments isa Vector{SExpr.Type}
+    @test isempty(x.arguments)
+
+    y = SExprExplicit.Add()
+    @test y.arguments isa Vector{SExprExplicit.Type}
+    @test isempty(y.arguments)
+
+    p = SExprP.Add{Int}()
+    @test p.arguments isa Vector{SExprP.Type{Int}}
+    @test isempty(p.arguments)
+end # issue #33


### PR DESCRIPTION
Fixes two closely-related bugs in how `@data` handles self-referential /
container-collapsing field types. Both stem from the fact that such fields are
stored as `Any` in the variant storage struct (the wrapper `Type` doesn't exist
yet, and self-references can't be named), so Julia's inner constructor performs
no conversion.

## #32 — convert constructor arguments to declared field types

When a declared field type collapses to `Any` in storage (a `Vector{Any}` field
or a self-referential `Vector{Self}`), the inner constructor stored the value
unchanged while `getproperty` / `variant_getfield` type-asserted against the
declared annotation, raising a `TypeError`.

Both the positional and keyword constructors now `Base.convert` each argument to
its declared annotation type, restoring normal struct-construction semantics. The
conversion is a no-op when the value already matches, so construction stays type
stable, and it lets the explicit-brace form of self-referential constructors
promote a parametric singleton bottom (e.g. `Empty()`).

## #33 — resolve the ADT name to `.Type` in default values

Inside the generated module the bare ADT name resolves to the *module*, so a
self-referential default like:

```julia
@data SExpr begin
    struct Add
        arguments::Vector{SExpr} = SExpr[]
    end
end

SExpr.Add()   # ERROR: MethodError: no method matching getindex(::Module)
```

expanded `SExpr[]` to `getindex(::Module)` and errored. The declared field type
already treated `SExpr` as `SExpr.Type`; the default value did not.

New `eval_default` processes a field's default like `eval_global_ref` but
additionally rewrites the ADT name (and its explicit `SExpr.Type` / `SExpr{...}`
forms) to the module-local `Type` alias, so the name means `SExpr.Type` in
defaults just as in field types. Qualified access such as `SExpr.Add` is
preserved so variant constructors stay reachable.

## Tests

- `test/data/emit/container.jl` — regression tests for #32 (`Vector{Any}` and
  self-referential `Vector{Self}` fields across anonymous/named/keyword
  constructors; explicit-brace self-ref promotion for #34).
- `test/data/emit/selfref.jl` — regression tests for #33 (bare name, explicit
  `.Type`, and parametric `SExpr{T}[]` defaults).
- Full suite passes: `data 310`, `match 121`, `derive 30`, `perf 5`.

Fixes #32
Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)