### PR TITLE
feat(data): support `export` statement inside `@data` block

### DIFF
--- a/docs/src/content/docs/data/syntax.mdx
+++ b/docs/src/content/docs/data/syntax.mdx
@@ -61,8 +61,10 @@ The syntax is as follows:
 
 ```julia
 <data> := @data <ident> [ <supertype> ] begin
+    [ <export> ]
     <variant>+
 end
+<export> := export <ident> ( , <ident> )*
 <variant> := <singleton> | <anonymous> | <named>
 <singleton> := <ident> ( )
 <anonymous> := <ident> ( <type>+ )
@@ -205,6 +207,43 @@ SExpr.Add()  # arguments === SExpr.Type[]
 
 Writing `SExpr.Type[]` explicitly is equivalent. See
 [issue #33](https://github.com/Roger-luo/Moshi.jl/issues/33).
+
+</Aside>
+
+## Exporting Variants
+
+By default the `@data` namespace only marks its variant constructors as
+[`public`](https://docs.julialang.org/en/v1/base/base/#public) (on Julia 1.11+),
+so you always reach them through the namespace, e.g. `Message.Quit()`. If you
+want some variants to be brought into scope automatically when the namespace is
+`using`ed, list them in an `export` statement inside the `@data` body:
+
+```julia
+@data Shape begin
+    export Circle, Square
+
+    Circle(Float64)
+    Square(Float64)
+    Triangle(Float64, Float64)
+end
+
+using .Shape          # brings `Circle` and `Square` into scope
+
+Circle(1.0)           # no need to write `Shape.Circle(1.0)`
+Square(2.0)
+Shape.Triangle(3.0, 4.0)  # `Triangle` was not exported
+```
+
+Only the listed variants are exported; the rest stay `public`-only. Every name
+in the `export` list must be a variant of the data type, otherwise the macro
+raises an error.
+
+<Aside type="tip">
+
+This is opt-in on purpose — scoping variants behind the namespace keeps a
+codebase readable. Reach for `export` when a handful of variants are used often
+enough that the namespace prefix becomes noise. See
+[issue #45](https://github.com/Roger-luo/Moshi.jl/issues/45) for the discussion.
 
 </Aside>
 

--- a/src/data/cons.jl
+++ b/src/data/cons.jl
@@ -48,6 +48,7 @@ function TypeDef(
     Meta.isexpr(body, :block) ||
         throw(ArgumentError("expect begin ... end block, got $body"))
     variants = Variant[]
+    exports = Symbol[]
     current_line = nothing
     for expr in body.args
         if expr isa LineNumberNode
@@ -55,10 +56,38 @@ function TypeDef(
             continue
         elseif isnothing(expr) # sometimes there are generated nothing in the block
             continue
+        elseif Meta.isexpr(expr, :export)
+            push_exports!(exports, expr)
+            continue
         end
         push_variants!(variants, expr, nothing, current_line)
     end
-    return TypeDef(mod, ismutable, head, variants, source)
+    validate_exports(head, variants, exports)
+    return TypeDef(mod, ismutable, head, variants, exports, source)
+end
+
+function push_exports!(exports::Vector{Symbol}, expr::Expr)
+    for name in expr.args
+        name isa Symbol || throw(
+            ArgumentError(
+                "invalid `export` in @data body: expected variant names, got `$expr`"
+            ),
+        )
+        push!(exports, name)
+    end
+    return nothing
+end
+
+function validate_exports(
+    head::TypeHead, variants::Vector{Variant}, exports::Vector{Symbol}
+)
+    variant_names = Set(variant.name for variant in variants)
+    for name in exports
+        name in variant_names || throw(
+            ArgumentError("cannot export `$name`: it is not a variant of `$(head.name)`"),
+        )
+    end
+    return nothing
 end
 
 TypeHead(head) = scan_type_head!(TypeHead(), head)

--- a/src/data/emit/public.jl
+++ b/src/data/emit/public.jl
@@ -1,7 +1,15 @@
 @pass 10 function emit_public(info::EmitInfo)
-    VERSION > v"1.11-" || return nothing
-    return expr_map(info.storages) do storage
-        # see JuliaLang/julia/issues/51450
-        Expr(:public, storage.parent.name)
+    exports = info.def.exports
+    stmts = []
+    for storage in info.storages
+        name = storage.parent.name
+        if name in exports
+            push!(stmts, Expr(:export, name))
+        elseif VERSION > v"1.11-"
+            # see JuliaLang/julia/issues/51450
+            push!(stmts, Expr(:public, name))
+        end
     end
+    isempty(stmts) && return nothing
+    return Expr(:block, stmts...)
 end

--- a/src/data/repr.jl
+++ b/src/data/repr.jl
@@ -85,5 +85,6 @@ struct TypeDef
     ismutable::Bool
     head::TypeHead
     variants::Vector{Variant}
+    exports::Vector{Symbol} # variant names to `export` (rest are only `public`)
     source::LineNumberNode
 end

--- a/test/data/emit/export.jl
+++ b/test/data/emit/export.jl
@@ -1,0 +1,71 @@
+using Test
+using Moshi.Data: @data
+
+module ExportVariants
+using Moshi.Data: @data
+
+@data Shape begin
+    export Circle, Square
+
+    Circle(Float64)
+    Square(Float64)
+    Triangle(Float64, Float64)
+end
+
+# `using` the generated ADT module should bring only the exported
+# constructors into scope.
+module Consumer
+    using ..Shape
+end # module Consumer
+end # module ExportVariants
+
+# an ADT without an `export` statement keeps the default (public-only) behavior.
+@data NoExport begin
+    A()
+    B(Int)
+end
+
+@testset "export selected variants" begin
+    Shape = ExportVariants.Shape
+
+    @test Base.isexported(Shape, :Circle)
+    @test Base.isexported(Shape, :Square)
+    @test !Base.isexported(Shape, :Triangle)
+
+    @static if VERSION >= v"1.11-"
+        # `export` implies public; non-exported variants stay public.
+        @test Base.ispublic(Shape, :Circle)
+        @test Base.ispublic(Shape, :Square)
+        @test Base.ispublic(Shape, :Triangle)
+    end
+
+    # only exported constructors are visible in a module that `using`s the ADT.
+    @test ExportVariants.Consumer.Circle === Shape.Circle
+    @test ExportVariants.Consumer.Square === Shape.Square
+    @test !isdefined(ExportVariants.Consumer, :Triangle)
+end
+
+@testset "no export statement stays public-only" begin
+    @test !Base.isexported(NoExport, :A)
+    @test !Base.isexported(NoExport, :B)
+    @static if VERSION >= v"1.11-"
+        @test Base.ispublic(NoExport, :A)
+        @test Base.ispublic(NoExport, :B)
+    end
+end
+
+@testset "export validation" begin
+    bad = :(@data BadExport begin
+        export Nope
+
+        Foo()
+    end)
+    err = try
+        macroexpand(@__MODULE__, bad)
+        nothing
+    catch e
+        e
+    end
+    @test err isa Exception
+    @test occursin("not a variant", sprint(showerror, err))
+end

--- a/test/data/emit/mod.jl
+++ b/test/data/emit/mod.jl
@@ -5,6 +5,7 @@ using Test
     include("unityper.jl")
     include("selfref.jl")
     include("empty_struct.jl")
+    include("export.jl")
 end
 
 @testset "generic" begin


### PR DESCRIPTION
## Summary

Closes #45.

Variants generated by `@data` are only marked [`public`](https://docs.julialang.org/en/v1/base/base/#public), so they must always be reached through the namespace (e.g. `Message.Quit()`). This PR implements the design settled on in the issue thread: an optional `export` statement inside the `@data` body that marks selected variants as `export`ed, so they are pulled into scope when the namespace is `using`ed.

```julia
@data Shape begin
    export Circle, Square

    Circle(Float64)
    Square(Float64)
    Triangle(Float64, Float64)
end

using .Shape          # brings `Circle` and `Square` into scope
Circle(1.0)           # no `Shape.` prefix needed
Square(2.0)
Shape.Triangle(3.0, 4.0)  # `Triangle` was not exported
```

Only the listed variants are exported; the rest keep the default `public`-only behavior. This stays opt-in on purpose — scoping variants behind the namespace keeps a codebase readable, per the discussion.

## Changes

- **`src/data/repr.jl`** — add an `exports::Vector{Symbol}` field to `TypeDef`.
- **`src/data/cons.jl`** — parse `export` statements in the `@data` body (`push_exports!`) and validate that every exported name is an actual variant (`validate_exports`), raising a clear error otherwise.
- **`src/data/emit/public.jl`** — emit `export <name>` for exported variants and `public <name>` for the rest. The `public` emission stays gated behind Julia ≥ 1.11, while `export` works on all versions.
- **`test/data/emit/export.jl`** — new tests: exported vs. non-exported (`Base.isexported`), `export` implies public while non-exported variants stay public (`Base.ispublic`), `using` the namespace brings only exported constructors into scope, no-`export` ADTs stay public-only, and the not-a-variant validation error.
- **`docs/src/content/docs/data/syntax.mdx`** — new "Exporting Variants" section + updated formal grammar.

## Testing

`julia --project -e 'using Pkg; Pkg.test()'` — all pass (data 325, match 121, derive 30, perf 5). Formatted with the `blue` style.

## Notes / follow-ups

- Design decision on `export` names is validated against declared variants; exporting an unknown name errors at macro-expansion.
- The issue also floated a `@derive ADT[ExportAll]` for exporting *everything*; that's intentionally left out of scope here (this PR is the explicit `export`-selected-variants form the issue landed on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)